### PR TITLE
Set crawler source from runtime configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,24 +2,14 @@
 version: '3.3'
 
 services:
-  # db:
-  #   image: postgis/postgis:12-3.0
-  #   environment:
-  #     POSTGRES_PASSWORD: changeMe
-  #     POSTGRES_DB: nldi
-  #   container_name: nldi-db
-  #   networks:
-  #     - nldi
-
   nldi-db:
-    image: nldi-db-demo
+    image: ghcr.io/internetofwater/nldi-db:demo
     container_name: nldi-db
     environment:
       POSTGRES_PASSWORD: changeMe
-      POSTGRES_DB: nldi
-      NLDI_DATABASE_ADDRESS: nldi-db
+      NLDI_DATABASE_ADDRESS: localhost
       NLDI_DATABASE_NAME: nldi
-      NLDI_DB_OWNER_USERNAME: root
+      NLDI_DB_OWNER_USERNAME: nldi
       NLDI_DB_OWNER_PASSWORD: changeMe
       NLDI_SCHEMA_OWNER_USERNAME: nldi_schema_owner
       NLDI_SCHEMA_OWNER_PASSWORD: changeMe
@@ -28,18 +18,26 @@ services:
       NLDI_READ_ONLY_PASSWORD: changeMe
     networks:
       - nldi
+    volumes:
+      - data:/var/lib/postgresql/data
 
-  nldi:
+  nldi-py:
     build:
       context: .
-    container_name: nldi
+    container_name: nldi-py
+    ports:
+      - "8080:80"
     environment:
-      NLDI_URL: http://localhost:8081/api/nldi
       NLDI_PATH: /api/nldi
+      NLDI_URL: http://localhost:8081/api/nldi
+      NLDI_DB_HOST: nldi-db
+      NLDI_DB_PORT: 5432
+      NLDI_DB_NAME: nldi
+      NLDI_DB_USERNAME: read_only_user
+      NLDI_DB_PASSWORD: changeMe
+      pygeoapiUrl: "https://labs.waterdata.usgs.gov/api/nldi/pygeoapi/"
     networks:
       - nldi
-    ports:
-      - "8081:80"
 
   pgadmin:
     container_name: pgadmin4_container
@@ -55,3 +53,5 @@ services:
 
 networks:
   nldi:
+volumes:
+  data:

--- a/nldi/api.py
+++ b/nldi/api.py
@@ -129,6 +129,13 @@ class API:
         if self._nldi_data_crawler_source is None:
             self._nldi_data_crawler_source = \
                 self.load_plugin('CrawlerSourceLookup')
+            try:
+                LOGGER.debug('Aligning configured sources with source table')
+                [self._nldi_data_crawler_source.align_source(source)
+                 for source in self.config['sources']]
+            except ProviderQueryError:
+                msg = 'Insufficient permission to update Crawler Source'
+                LOGGER.warning(msg)
         return self._nldi_data_crawler_source
 
     @property

--- a/nldi/api.py
+++ b/nldi/api.py
@@ -103,6 +103,15 @@ class API:
 
         self.pretty_print = self.config['server']['pretty_print']
 
+        if self.config.get('sources'):
+            sources = deepcopy(self.config['sources'])
+            LOGGER.debug('Aligning configuration with crawler source table')
+            try:
+                self.crawler_source.align_sources(sources)
+            except ProviderQueryError:
+                msg = 'Insufficient permission to update Crawler source'
+                LOGGER.error(msg)
+
         setup_logger(cfg['logging'])
 
     def load_plugin(self, plugin_name: str, **kwargs) -> Any:
@@ -129,13 +138,6 @@ class API:
         if self._nldi_data_crawler_source is None:
             self._nldi_data_crawler_source = \
                 self.load_plugin('CrawlerSourceLookup')
-            sources = deepcopy(self.config['sources'])
-            LOGGER.debug('Aligning configured sources with source table')
-            try:
-                self._nldi_data_crawler_source.align_sources(sources)
-            except ProviderQueryError:
-                msg = 'Insufficient permission to update Crawler Source'
-                LOGGER.error(msg)
         return self._nldi_data_crawler_source
 
     @property

--- a/nldi/api.py
+++ b/nldi/api.py
@@ -129,13 +129,13 @@ class API:
         if self._nldi_data_crawler_source is None:
             self._nldi_data_crawler_source = \
                 self.load_plugin('CrawlerSourceLookup')
+            sources = deepcopy(self.config['sources'])
+            LOGGER.debug('Aligning configured sources with source table')
             try:
-                LOGGER.debug('Aligning configured sources with source table')
-                [self._nldi_data_crawler_source.align_source(source)
-                 for source in self.config['sources']]
+                self._nldi_data_crawler_source.align_sources(sources)
             except ProviderQueryError:
                 msg = 'Insufficient permission to update Crawler Source'
-                LOGGER.warning(msg)
+                LOGGER.error(msg)
         return self._nldi_data_crawler_source
 
     @property

--- a/nldi/schemas/nldi_data.py
+++ b/nldi/schemas/nldi_data.py
@@ -28,7 +28,7 @@
 # =================================================================
 
 from geoalchemy2 import Geometry
-from sqlalchemy import MetaData, Column, Integer, String, Float, text
+from sqlalchemy import MetaData, Column, Integer, String, Float, text, Text
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 
@@ -41,29 +41,30 @@ class CrawlerSourceModel(BaseModel):
     __tablename__ = 'crawler_source'
 
     crawler_source_id = Column(Integer, primary_key=True)
-    source_name = Column(String)
-    source_suffix = Column(String, server_default=text("lower(source_suffix)"))
-    source_uri = Column(String)
-    feature_id = Column(String)
-    feature_name = Column(String)
-    feature_uri = Column(String)
-    feature_reach = Column(String, nullable=True)
-    feature_measure = Column(String, nullable=True)
-    ingest_type = Column(String)
-    feature_type = Column(String)
+    source_name = Column(String(500))
+    source_suffix = Column(String(10),
+                           server_default=text("lower(source_suffix)"))
+    source_uri = Column(String(256))
+    feature_id = Column(String(256))
+    feature_name = Column(String(256))
+    feature_uri = Column(String(256))
+    feature_reach = Column(String(256), nullable=True)
+    feature_measure = Column(String(256), nullable=True)
+    ingest_type = Column(String(5), nullable=True)
+    feature_type = Column(String(100), nullable=True)
 
 
 class FeatureSourceModel(BaseModel):
     __tablename__ = 'feature'
 
-    comid = Column(Integer, nullable=True)
-    identifier = Column(String, primary_key=True, nullable=True)
-    crawler_source_id = Column(Integer, nullable=True)
-    name = Column(String, nullable=True)
-    uri = Column(String, nullable=True)
-    reachcode = Column(String, nullable=True)
-    measure = Column(Float, nullable=True)
+    crawler_source_id = Column(Integer)
+    identifier = Column(String(256), primary_key=True, nullable=True)
+    name = Column(String(256), nullable=True)
+    uri = Column(String(256), nullable=True)
     location = Column(Geometry, nullable=True)
+    comid = Column(Integer, nullable=True)
+    reachcode = Column(String(14), nullable=True)
+    measure = Column(Float(38), nullable=True)
 
 
 class MainstemLookupModel(BaseModel):
@@ -71,7 +72,7 @@ class MainstemLookupModel(BaseModel):
 
     nhdpv2_comid = Column(Integer, primary_key=True, nullable=True)
     mainstem_id = Column(Integer, nullable=True)
-    uri = Column(String, nullable=True)
+    uri = Column(Text, nullable=True)
 
 
 FeatureSourceModel.mainstem_lookup = relationship(


### PR DESCRIPTION
If sources are included in `NLDI_CONFIG`, attempt to align configured sources with source_table on API init