### PR TITLE
trim down openapi doc generation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,13 +29,14 @@ services:
       - "8080:80"
     environment:
       NLDI_PATH: /api/nldi
-      NLDI_URL: http://localhost:80/api/nldi
+      NLDI_URL: http://localhost:80/
       NLDI_DB_HOST: nldi-db
       NLDI_DB_PORT: 5432
       NLDI_DB_NAME: nldi
       NLDI_DB_USERNAME: nldi
       NLDI_DB_PASSWORD: changeMe
       PYGEOAPI_URL: https://labs.waterdata.usgs.gov/api/nldi/pygeoapi/
+      springFrameworkLogLevel:
     networks:
       - nldi
 

--- a/docker/x.sh
+++ b/docker/x.sh
@@ -8,3 +8,4 @@ export NLDI_SCHEMA_OWNER_PASSWORD=changeMe
 export NHDPLUS_SCHEMA_OWNER_USERNAME=nhdplus
 export NLDI_READ_ONLY_USERNAME=read_only_user
 export NLDI_READ_ONLY_PASSWORD=changeMe
+export springFrameworkLogLevel=DEBUG

--- a/src/nldi/api/main.py
+++ b/src/nldi/api/main.py
@@ -482,6 +482,25 @@ class API:
             base_path = f"/linked-data/{src}"
             src_name = "Source" if src == "{sourceid}" else "comid"
             id_field = "{comid}" if src == "comid" else "{identifier}"
+
+            paths[f"{base_path}"] = {
+                "get": {
+                    "description": "returns all features.",
+                    "tags": ["by_comid" if src == "comid" else "by_sourceid"],
+                    "operationId": f"{src_name}AllFeatures",
+                    "responses": {
+                        "200": {
+                            "description": "OK",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "object", "additionalProperties": {"type": "object"}}
+                                }
+                            },
+                        },
+                        **RESPONSES,
+                    },
+                }
+            }
             params = [
                 {"$ref": "#/components/parameters/simplified"},
                 {"$ref": "#/components/parameters/splitCatchment"},

--- a/src/nldi/api/parameters.yaml
+++ b/src/nldi/api/parameters.yaml
@@ -7,6 +7,23 @@ identifier:
   schema:
     type: string
 
+sourceid:
+  name: sourceid
+  in: path
+  description: Source identifier
+  required: true
+  schema:
+    type: string
+
+comid:
+  name: comid,
+  in: path,
+  description: NHDPlus common identifier
+  required: True,
+  schema:
+    type: integer
+    example: 13294314
+
 simplified:
   name: simplified
   in: query

--- a/src/nldi/config.py
+++ b/src/nldi/config.py
@@ -15,40 +15,6 @@ from typing import Union
 
 from . import LOGGER, util
 
-# def align_crawler_sources(cfg_file: Union[pathlib.Path, io.TextIOWrapper]) -> bool:
-#     """
-#     Align Crawler Source from the configuration file
-
-#     :param cfg_file: Configuration Path instance
-#     :type cfg_file: Union[pathlib.Path, io.TextIOWrapper]
-#     :return: Success/Failure of alignment
-#     :rtype: bool
-#     """
-#     LOGGER.debug("Aligning sources from config file.")
-#     config = util.load_yaml(cfg_file)
-#     if not config:
-#         LOGGER.error("Unable to load configuration file.")
-#         return False
-
-#     if not config.get("sources"):
-#         LOGGER.debug("No sources to align with, continuing")
-#         return True
-
-#     provider_def = {
-#         "database": deepcopy(config["server"]["data"]),
-#         "base_url": get_base_url(config),
-#     }
-
-#     LOGGER.debug("Aligning configuration with crawler source table")
-#     try:
-#         crawler_source = CrawlerSourceLookup(provider_def)
-#         crawler_source.align_sources(config["sources"])
-#     except ProviderQueryError:
-#         LOGGER.error("Provider Query Error -- Do you have permissions to update Crawler source table?")
-#         return False
-
-#     return True
-
 
 class Configuration(UserDict):
     """Data class for holding global configuration."""
@@ -71,6 +37,7 @@ class Configuration(UserDict):
             for k, v in dict(
                 # NLDI_PATH="/api/nldi",
                 NLDI_URL="http://localhost:8081/",
+                NLDI_PATH="/api/nldi",
                 NLDI_DB_HOST="172.17.0.2",  # This is the IP address for the Docker container
                 NLDI_DB_PORT="5432",
                 NLDI_DB_NAME="nldi",
@@ -82,7 +49,12 @@ class Configuration(UserDict):
                     ENV[k] = v
 
         self.data = util.load_yaml(cfg_src)
-        self.data["base_url"] = util.url_join(self.data["server"]["url"], "")
+
+        self.data["base_url"] = util.url_join(
+            self.data["server"].get("url", "http://localhost/"),
+            self.data["server"].get("prefix", ""),
+            "",
+        )
 
         if isinstance(cfg_src, io.TextIOWrapper):
             self._config_src = "<stream>"

--- a/tests/data/sources_config.yml
+++ b/tests/data/sources_config.yml
@@ -1,5 +1,6 @@
 server:
   url: ${NLDI_URL}
+  prefix: ${NLDI_PATH}
   pretty_print: false
   data:
     host: ${NLDI_DB_HOST}
@@ -9,8 +10,7 @@ server:
     password: ${NLDI_DB_PASSWORD}
 
 logging:
-  level: ERROR
-  logfile: /tmp/nldi.log
+  level: DEBUG
 
 pygeoapi_url: https://labs.waterdata.usgs.gov/api/nldi/pygeoapi
 


### PR DESCRIPTION
do not generate a tag and group of endpoints per source -- one group (and tag) with {sourcid} being a path param. 

