### PR TITLE
58 case insensitive repo get

### DIFF
--- a/tests/40_crawler_sources_test.py
+++ b/tests/40_crawler_sources_test.py
@@ -27,6 +27,7 @@ Crawler Sources
 
 import pytest
 from advanced_alchemy.exceptions import NotFoundError
+from sqlalchemy import func
 
 from nldi.db.schemas.nldi_data import CrawlerSourceModel
 from nldi.domain.linked_data import repos, services
@@ -51,9 +52,9 @@ async def test_source_repo_get_by_id(dbsession_containerized) -> None:
 async def test_source_repo_lookup_by_suffix(dbsession_containerized) -> None:
     src_repo = repos.CrawlerSourceRepository(session=dbsession_containerized)
 
-    feature = await src_repo.get_one_or_none(CrawlerSourceModel.source_suffix == "WQP")
-    # NOTE:  The REPO needs to match exactly (including case); the service which uses this repo will conduct a case-insensitive search.
-    assert feature.source_suffix.lower() == "wqp"
+    feature = await src_repo.get_one_or_none(
+        func.lower(CrawlerSourceModel.source_suffix) == "WQP".lower(),
+    )
     assert feature.crawler_source_id == 1  # < known value for this source.
 
 

--- a/tests/40_crawler_sources_test.py
+++ b/tests/40_crawler_sources_test.py
@@ -51,7 +51,8 @@ async def test_source_repo_get_by_id(dbsession_containerized) -> None:
 async def test_source_repo_lookup_by_suffix(dbsession_containerized) -> None:
     src_repo = repos.CrawlerSourceRepository(session=dbsession_containerized)
 
-    feature = await src_repo.get_one_or_none(CrawlerSourceModel.source_suffix == "wqp")
+    feature = await src_repo.get_one_or_none(CrawlerSourceModel.source_suffix == "WQP")
+    # NOTE:  The REPO needs to match exactly (including case); the service which uses this repo will conduct a case-insensitive search.
     assert feature.source_suffix.lower() == "wqp"
     assert feature.crawler_source_id == 1  # < known value for this source.
 
@@ -82,15 +83,15 @@ async def test_source_service_search_by_suffix(dbsession_containerized) -> None:
     src_svc = services.CrawlerSourceService(session=dbsession_containerized)
 
     feature = await src_svc.get_by_suffix("wqp")
-    assert feature.source_suffix == "wqp"
+    assert feature.source_suffix.lower() == "wqp"
 
     ## Case insensitive:
     feature = await src_svc.get_by_suffix("WQP")
-    assert feature.source_suffix == "wqp"
+    assert feature.source_suffix.lower() == "wqp"
 
     ## weird case:
     feature = await src_svc.get_by_suffix("wQp")
-    assert feature.source_suffix == "wqp"
+    assert feature.source_suffix.lower() == "wqp"
 
 
 @pytest.mark.order(42)

--- a/tests/60_features_test.py
+++ b/tests/60_features_test.py
@@ -41,6 +41,7 @@ from advanced_alchemy.exceptions import NotFoundError
 
 from nldi.db.schemas.nldi_data import FeatureSourceModel
 from nldi.domain.linked_data import repos, services
+from sqlalchemy import func
 
 from . import API_PREFIX
 
@@ -52,22 +53,14 @@ async def test_feature_repo_get(dbsession_containerized) -> None:
     feature_repo = repos.FeatureRepository(session=dbsession_containerized)
 
     identifier = "USGS-05427930"  # < this ID and source must be in the containerized DB.
-    source_name = "WQP"  # NOTE: repo is case-sensitive; the service isn't
+    source_name = "wqp"
 
     ## "old" lookup method, without association proxies on FeatureSourceModel
     sources_svc = services.CrawlerSourceService(session=dbsession_containerized)
     _src = await sources_svc.get_by_suffix(source_name)
     _feature = await feature_repo.get_one_or_none(
-        FeatureSourceModel.identifier == identifier, FeatureSourceModel.crawler_source_id == _src.crawler_source_id
-    )
-
-    assert _feature is not None
-    assert _feature.comid == 13294176  # < NOTE: integer; not a string
-    assert _feature.name.startswith("DORN (SPRING) CREEK")
-
-    ## "new" lookup method, with association proxies to simplify matching the source; i.e. no need to separately lookup source ID.
-    _feature = await feature_repo.get_one_or_none(
-        FeatureSourceModel.source == source_name, FeatureSourceModel.identifier == identifier
+        FeatureSourceModel.identifier == identifier,
+        FeatureSourceModel.crawler_source_id == _src.crawler_source_id,
     )
 
     assert _feature is not None
@@ -102,11 +95,11 @@ async def test_feature_repo_get_all(dbsession_containerized) -> None:
     feature_repo = repos.FeatureRepository(session=dbsession_containerized)
     sources_svc = services.CrawlerSourceService(session=dbsession_containerized)
 
-    source_name = "WQP"
+    source_name = "wqp"
 
     # Invalid source name is tested elsewhere. 40_crawler_sources_test.py
     _src = await sources_svc.get_by_suffix(source_name)
-    assert _src.source_suffix == source_name
+    assert _src.source_suffix.lower() == source_name
 
     _features = await feature_repo.list(FeatureSourceModel.crawler_source_id == _src.crawler_source_id)
 

--- a/tests/60_features_test.py
+++ b/tests/60_features_test.py
@@ -52,7 +52,7 @@ async def test_feature_repo_get(dbsession_containerized) -> None:
     feature_repo = repos.FeatureRepository(session=dbsession_containerized)
 
     identifier = "USGS-05427930"  # < this ID and source must be in the containerized DB.
-    source_name = "wqp"
+    source_name = "WQP"  # NOTE: repo is case-sensitive; the service isn't
 
     ## "old" lookup method, without association proxies on FeatureSourceModel
     sources_svc = services.CrawlerSourceService(session=dbsession_containerized)
@@ -86,7 +86,7 @@ async def test_feature_repo_get_notfound(dbsession_containerized) -> None:
 
     # Invalid source name is tested elsewhere. 40_crawler_sources_test.py
     _src = await sources_svc.get_by_suffix(source_name)
-    assert _src.source_suffix == source_name
+    assert _src.source_suffix.lower() == source_name
 
     _feature = await feature_repo.get_one_or_none(
         FeatureSourceModel.identifier == identifier,
@@ -102,7 +102,7 @@ async def test_feature_repo_get_all(dbsession_containerized) -> None:
     feature_repo = repos.FeatureRepository(session=dbsession_containerized)
     sources_svc = services.CrawlerSourceService(session=dbsession_containerized)
 
-    source_name = "wqp"
+    source_name = "WQP"
 
     # Invalid source name is tested elsewhere. 40_crawler_sources_test.py
     _src = await sources_svc.get_by_suffix(source_name)


### PR DESCRIPTION
Not actually sure if it was the nldi-db database that changed (`wqp` -> `WQP`) or if I had inadvertently changed the test data on the mounted volume inside docker.   

Either way -- with a fresh pull I have "correct" test data and current tests now pass. 
