### PR TITLE
Remove alternate openapi documents

### DIFF
--- a/src/nldi/server/openapi.py
+++ b/src/nldi/server/openapi.py
@@ -65,11 +65,6 @@ def generate_openapi_json():
         },
         "servers": [
             {"url": _CFG.server.base_url, "description": _CFG.metadata.title},
-            {"url": "https://labs.waterdata.usgs.gov/api/nldi", "description": "Network Linked Data Index API"},
-            {
-                "url": "https://labs-beta.waterdata.usgs.gov/api/nldi/",
-                "description": "Network Linked Data Index API - Beta",
-            },
         ],
         "components": {
             "schemas": OAS_SCHEMAS,


### PR DESCRIPTION
Remove alternate openapi documents now that there is a public NLDI python endpoint. This was originally to allow the python implementation to directly be compared to the Java implementation.