### PR TITLE
HOTFIX for #87

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nldi-py"
-version = "2.0.3"
+version = "2.0.4"
 description = "The Hydro Network Linked Data Index (NLDI) puts a restful application programming interface (API) in front of the National Hydrolography dataset (NHD). Now, instead of needing to be a GIS professional, any web developer can build tools against the core data in the NHD in a scalable, workable way."
 authors = ["Internet of Water"]
 maintainers = ["Benjamin Webb <bwebb@lincolninst.edu>"]

--- a/src/nldi/__init__.py
+++ b/src/nldi/__init__.py
@@ -5,11 +5,9 @@
 #
 """Network Linked Data Index (NLDI) Python package."""
 
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 
 import logging
-
-# from . import log
 
 NAD83_SRID = 4269
 

--- a/src/nldi/server/linked_data/endpoints.py
+++ b/src/nldi/server/linked_data/endpoints.py
@@ -294,7 +294,10 @@ def get_basin_by_id(source_name: str, identifier: str) -> dict[str, Any]:
             session=db_session,
             pygeoapi_url=flask.current_app.NLDI_CONFIG.server.pygeoapi_url,
         )
-        featurelist = basin_svc.get_by_id(identifier, source_name, simplified, split)
+        try:
+            featurelist = basin_svc.get_by_id(identifier, source_name, simplified, split)
+        except Exception as e:
+            raise ServiceUnavailable("Unable to get/split basin") from e
 
         _r = flask.Response(
             headers={"Content-Type": "application/json"},

--- a/src/nldi/server/linked_data/endpoints.py
+++ b/src/nldi/server/linked_data/endpoints.py
@@ -87,7 +87,8 @@ def parse_incoming_request() -> None:
 @LINKED_DATA.after_request
 def ld_update_headers(r: flask.Response) -> flask.Response:
     """Implement simple middlware function to update response headers."""
-    r.headers.update({"X-Powered-By": f"nldi {__version__} and FLASK"})
+    r.headers.update({"X-Powered-By": f"nldi-py {__version__}"})
+    r.headers.update({"X-NLDI-Version": f"nldi-py {__version__}"})  ## extra header -- to see if the proxy strips it
     return r
 
 

--- a/src/nldi/server/linked_data/services/flowline.py
+++ b/src/nldi/server/linked_data/services/flowline.py
@@ -198,7 +198,7 @@ class FlowlineService(FlaskServiceMixin, SQLAlchemySyncRepositoryService[Flowlin
         )
 
         stmt = (
-            sqlalchemy.select([sqlalchemy.func.ST_X(point).label("lon"), sqlalchemy.func.ST_Y(point).label("lat")])
+            sqlalchemy.select(sqlalchemy.func.ST_X(point).label("lon"), sqlalchemy.func.ST_Y(point).label("lat"))
             .join(
                 FeatureSourceModel,
                 sqlalchemy.and_(
@@ -216,7 +216,7 @@ class FlowlineService(FlaskServiceMixin, SQLAlchemySyncRepositoryService[Flowlin
         ).params(feature_id=feature_id, feature_source=feature_source)
 
         logging.debug(stmt.compile())
-        hits = self.repository.execute(stmt)
+        hits = self.repository._execute(stmt)
 
         pt = hits.fetchone()
         if pt is None or None in pt:


### PR DESCRIPTION

Definitely a hole in my testing scheme.  This endpoint not exercised properly. 

The error has to do with the change in `sqlalchemy`'s API for select statements.  In v1.x the load_only columns are supplied in *args as an interable.  When I moved to sqlalchemny 2.x, that behavior changed to *args being the columns/expressions to load.  Just needed to remove the `[]` around the list and we're good. 

