### PR TITLE
1.1: App entry point and config

### DIFF
--- a/src/nldi/asgi.py
+++ b/src/nldi/asgi.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2024-present USGS
+"""ASGI application factory."""
+
+from litestar import Litestar
+from litestar.logging import LoggingConfig
+
+from . import __version__
+from .config import get_log_level, get_prefix
+
+
+def create_app() -> Litestar:
+    return Litestar(
+        route_handlers=[],
+        path=get_prefix(),
+        logging_config=LoggingConfig(root={"level": get_log_level(), "handlers": ["queue_listener"]}),
+    )
+
+
+app = create_app()

--- a/src/nldi/config.py
+++ b/src/nldi/config.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2024-present USGS
+"""Application configuration via environment variables."""
+
+import logging
+import os
+
+
+def get_prefix() -> str:
+    return os.getenv("NLDI_PREFIX", "/api/nldi")
+
+
+def get_log_level() -> int:
+    name = os.getenv("NLDI_LOG_LEVEL", "WARNING").upper()
+    return logging.getLevelNamesMapping().get(name, logging.WARNING)

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,0 +1,16 @@
+from litestar.testing import TestClient
+
+from nldi.asgi import create_app
+
+
+def test_app_creates():
+    app = create_app()
+    assert app is not None
+
+
+def test_app_responds():
+    app = create_app()
+    with TestClient(app=app) as client:
+        # No routes defined yet, so root should 404 (or whatever litestar returns)
+        r = client.get("/api/nldi/")
+        assert r.status_code in (404, 200)  # no routes = 404 is fine

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,34 @@
+import os
+
+from nldi.config import get_log_level, get_prefix
+
+
+def test_default_prefix():
+    os.environ.pop("NLDI_PREFIX", None)
+    assert get_prefix() == "/api/nldi"
+
+
+def test_custom_prefix(monkeypatch):
+    monkeypatch.setenv("NLDI_PREFIX", "/custom")
+    assert get_prefix() == "/custom"
+
+
+def test_default_log_level():
+    os.environ.pop("NLDI_LOG_LEVEL", None)
+    import logging
+
+    assert get_log_level() == logging.WARNING
+
+
+def test_custom_log_level(monkeypatch):
+    import logging
+
+    monkeypatch.setenv("NLDI_LOG_LEVEL", "DEBUG")
+    assert get_log_level() == logging.DEBUG
+
+
+def test_invalid_log_level_falls_back(monkeypatch):
+    import logging
+
+    monkeypatch.setenv("NLDI_LOG_LEVEL", "NONSENSE")
+    assert get_log_level() == logging.WARNING


### PR DESCRIPTION
## What

Phase 1, PR 1 from the roadmap. Minimal Litestar app that starts and responds.

## Plan

1. `src/nldi/config.py` — read config from env vars with sensible defaults:
   - `NLDI_PREFIX` (default: `/api/nldi`)
   - `NLDI_LOG_LEVEL` (default: `WARNING`)
2. `src/nldi/asgi.py` — bare Litestar app, no routes yet, just the app factory
3. Unit test: app creates, config reads env vars, defaults work

No DB, no routes, no middleware (that's 1.2+).

## Acceptance criteria

- `uv sync` succeeds (no new deps needed — litestar already present)
- App starts: `uv run uvicorn nldi.asgi:app`
- `task check` passes
- Unit tests cover config defaults and env var override