### PR TITLE
1.3: Error handling — RFC 9457 problem+json

### DIFF
--- a/src/nldi/errors.py
+++ b/src/nldi/errors.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2024-present USGS
+"""RFC 9457 Problem Details error handlers."""
+
+import logging
+import uuid
+from http import HTTPStatus
+from typing import Any
+
+from litestar import Request, Response
+from litestar.exceptions import HTTPException
+
+PROBLEM_JSON = "application/problem+json"
+
+
+logger = logging.getLogger(__name__)
+
+
+def problem_details_handler(_request: Request[Any, Any, Any], exc: HTTPException) -> Response[dict[str, Any]]:
+    """Return an RFC 9457 Problem Details response for HTTP exceptions."""
+    title = HTTPStatus(exc.status_code).phrase if exc.status_code in HTTPStatus else "Error"
+    body: dict[str, Any] = {
+        "type": "about:blank",
+        "title": title,
+        "status": exc.status_code,
+        "detail": exc.detail,
+    }
+    return Response(content=body, status_code=exc.status_code, media_type=PROBLEM_JSON)
+
+
+def unhandled_exception_handler(_request: Request[Any, Any, Any], exc: Exception) -> Response[dict[str, Any]]:
+    """Return a generic 500 Problem Details response for unhandled exceptions.
+
+    Logs the full traceback server-side with a reference ID.
+    The reference ID is returned to the client via the ``instance`` field
+    so it can be used to correlate error reports with log entries.
+    """
+    ref = uuid.uuid4().hex[:8]
+    logger.exception("Unhandled exception [%s]", ref)
+    body: dict[str, Any] = {
+        "type": "about:blank",
+        "title": "Internal Server Error",
+        "status": 500,
+        "detail": "An unexpected error occurred.",
+        "instance": f"urn:error:{ref}",
+    }
+    return Response(content=body, status_code=500, media_type=PROBLEM_JSON)

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,0 +1,98 @@
+from litestar import Litestar, get
+from litestar.exceptions import NotFoundException
+from litestar.testing import TestClient
+
+
+def _make_app() -> Litestar:
+    from nldi.errors import problem_details_handler, unhandled_exception_handler
+
+    @get("/found")
+    async def found_route() -> dict:
+        return {"ok": True}
+
+    @get("/missing")
+    async def missing_route() -> dict:
+        raise NotFoundException(detail="Thing not found")
+
+    @get("/broken")
+    async def broken_route() -> dict:
+        raise RuntimeError("something broke internally")
+
+    return Litestar(
+        route_handlers=[found_route, missing_route, broken_route],
+        exception_handlers={
+            NotFoundException: problem_details_handler,
+            Exception: unhandled_exception_handler,
+        },
+    )
+
+
+def test_not_found_returns_problem_json():
+    with TestClient(app=_make_app()) as client:
+        r = client.get("/missing")
+        assert r.status_code == 404
+        assert r.headers["content-type"] == "application/problem+json"
+        body = r.json()
+        assert body["type"] == "about:blank"
+        assert body["title"] == "Not Found"
+        assert body["status"] == 404
+        assert body["detail"] == "Thing not found"
+
+
+def test_bad_request_returns_problem_json():
+    from litestar.exceptions import ClientException
+
+    def _make_app_400():
+        from nldi.errors import problem_details_handler, unhandled_exception_handler
+
+        @get("/bad")
+        async def bad_route() -> dict:
+            raise ClientException(detail="Invalid parameter")
+
+        return Litestar(
+            route_handlers=[bad_route],
+            exception_handlers={ClientException: problem_details_handler, Exception: unhandled_exception_handler},
+        )
+
+    with TestClient(app=_make_app_400()) as client:
+        r = client.get("/bad")
+        assert r.status_code == 400
+        assert r.headers["content-type"] == "application/problem+json"
+        body = r.json()
+        assert body["title"] == "Bad Request"
+        assert body["detail"] == "Invalid parameter"
+
+
+def test_unhandled_exception_returns_500_problem_json():
+    with TestClient(app=_make_app()) as client:
+        r = client.get("/broken")
+        assert r.status_code == 500
+        assert r.headers["content-type"] == "application/problem+json"
+        body = r.json()
+        assert body["type"] == "about:blank"
+        assert body["title"] == "Internal Server Error"
+        assert body["status"] == 500
+        assert body["detail"] == "An unexpected error occurred."
+        assert "instance" in body
+        assert body["instance"].startswith("urn:error:")
+
+
+def test_500_does_not_leak_internal_details():
+    with TestClient(app=_make_app()) as client:
+        r = client.get("/broken")
+        body = r.text
+        assert "something broke internally" not in body
+        assert "Traceback" not in body
+        assert "RuntimeError" not in body
+
+
+def test_500_logs_reference_id():
+    from unittest.mock import patch
+
+    with patch("nldi.errors.logger") as mock_logger:
+        with TestClient(app=_make_app()) as client:
+            r = client.get("/broken")
+            ref = r.json()["instance"].split(":")[-1]
+            mock_logger.exception.assert_called_once()
+            logged_ref = mock_logger.exception.call_args[0][1]
+            assert logged_ref == ref


### PR DESCRIPTION
## What

Phase 1, PR 3 from the roadmap. All errors return consistent RFC 9457 Problem Details responses.

## Behavior checklist (TDD)

- [ ] HTTPException (e.g. 404) returns `application/problem+json` with type, title, status, detail
- [ ] 400 returns problem+json with detail from exception
- [ ] Title matches HTTP status phrase (e.g. "Not Found" for 404)
- [ ] Unhandled exceptions return 500 problem+json with generic detail (no stack trace leak)
- [ ] Unhandled exceptions include `instance` field with a reference ID
- [ ] Reference ID is logged server-side with the full traceback

## Approach

Two exception handlers registered on the Litestar app:
1. `HTTPException` → problem+json with real status/detail
2. `Exception` (catch-all) → 500 problem+json with generic message, reference ID, server-side logging

Uses RFC 9457 `instance` field for error correlation between client and logs.

## Acceptance criteria

- All behaviors have passing unit tests
- `task check` passes
- No internal details leaked in 500 responses