### PR TITLE
1.6: Legacy redirects — swagger-ui and openapi

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,18 +12,18 @@ Housekeeping before any feature work.
 | ~~0.1~~ | Clean `src/` tree, `pyproject.toml` with minimal deps | ✅ #156 |
 | ~~0.2~~ | Taskfile + test reorganization (combined 0.2 and 0.3) | ✅ #157 |
 
-## Phase 1: Skeleton
+## Phase 1: Skeleton ✅
 
 All routes respond. Nothing touches the DB.
 
-| PR | Description | Depends on | Acceptance |
-| --- | --- | --- | --- |
-| 1.1 | App entry point, config via env vars, Litestar app shell | 0.2 | App starts, responds on `/` |
-| 1.2 | Middleware stack: CORS (unconditional), HEAD (fast-return), Cache-Control, Vary | 1.1 | Headers correct on every response (unit tests) |
-| 1.3 | Error handling: RFC 9457 problem+json, exception handlers for 400/404/500/503/504 | 1.1 | Errors return `application/problem+json` with correct status codes |
-| 1.4 | Content negotiation: `f=` validation (400 on invalid), browser redirect (`Accept: text/html` → click-here page) | 1.1 | Invalid `f=` rejected, browser redirect works |
-| 1.5 | Route stubs: all endpoints defined, return 501. Health check (no DB). OpenAPI generation. | 1.1–1.4 | Every endpoint responds, OpenAPI spec matches expected paths |
-| 1.6 | Legacy redirects: `/swagger-ui/index.html` → `/docs`, `/openapi` → `/docs` | 1.5 | Redirects return 301/302 to correct paths |
+| PR | Description | Status |
+| --- | --- | --- |
+| ~~1.1~~ | App entry point, config via env vars, Litestar app shell | ✅ #158 |
+| ~~1.2~~ | Middleware: CORS (unconditional), Cache-Control, Vary | ✅ #159 |
+| ~~1.3~~ | Error handling: RFC 9457 problem+json with error reference IDs | ✅ #160 |
+| ~~1.4~~ | Content negotiation: `f=` validation, browser redirect, MediaType enum | ✅ #161 |
+| ~~1.5~~ | Route stubs (501), health check, HEAD via `@head` multi-path, wiring | ✅ #162 |
+| ~~1.6~~ | Legacy redirects: `/swagger-ui/index.html` → `/docs`, `/openapi` → `/docs` | ✅ #163 |
 
 ## Phase 2: Read-only lookups
 

--- a/src/nldi/controllers/root.py
+++ b/src/nldi/controllers/root.py
@@ -3,6 +3,7 @@
 """Root controller — landing page and health check."""
 
 from litestar import Controller, get, head
+from litestar.response import Redirect
 
 from ..media import MediaType
 
@@ -40,3 +41,13 @@ class RootController(Controller):
     async def health_check(self) -> dict:
         """Health check."""
         return {"status": "ok"}
+
+    @get("/swagger-ui/index.html", include_in_schema=False)
+    async def swagger_ui_redirect(self) -> Redirect:
+        """Redirect legacy Java Swagger UI path to docs."""
+        return Redirect(path="/api/nldi/docs", status_code=301)
+
+    @get("/openapi", include_in_schema=False)
+    async def openapi_redirect(self) -> Redirect:
+        """Redirect legacy OpenAPI path to docs."""
+        return Redirect(path="/api/nldi/docs", status_code=301)

--- a/src/nldi/controllers/root.py
+++ b/src/nldi/controllers/root.py
@@ -5,6 +5,7 @@
 from litestar import Controller, get, head
 from litestar.response import Redirect
 
+from ..config import get_prefix
 from ..media import MediaType
 
 
@@ -45,9 +46,9 @@ class RootController(Controller):
     @get("/swagger-ui/index.html", include_in_schema=False)
     async def swagger_ui_redirect(self) -> Redirect:
         """Redirect legacy Java Swagger UI path to docs."""
-        return Redirect(path="/api/nldi/docs", status_code=301)
+        return Redirect(path=f"{get_prefix()}/docs", status_code=301)
 
     @get("/openapi", include_in_schema=False)
     async def openapi_redirect(self) -> Redirect:
         """Redirect legacy OpenAPI path to docs."""
-        return Redirect(path="/api/nldi/docs", status_code=301)
+        return Redirect(path=f"{get_prefix()}/docs", status_code=301)

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -87,3 +87,17 @@ def test_head_nonexistent_returns_404():
     with _client() as client:
         r = client.head("/api/nldi/nonexistent")
         assert r.status_code == 404
+
+
+def test_swagger_ui_redirects_to_docs():
+    with _client() as client:
+        r = client.get("/api/nldi/swagger-ui/index.html", follow_redirects=False)
+        assert r.status_code == 301
+        assert "/api/nldi/docs" in r.headers["location"]
+
+
+def test_openapi_redirects_to_docs():
+    with _client() as client:
+        r = client.get("/api/nldi/openapi", follow_redirects=False)
+        assert r.status_code == 301
+        assert "/api/nldi/docs" in r.headers["location"]


### PR DESCRIPTION
## What

Phase 1, PR 6 from the roadmap. Redirect legacy Java paths to the new docs.

## Behavior checklist (TDD)

- [ ] `GET /swagger-ui/index.html` → 301 to `/docs`
- [ ] `GET /openapi` → 301 to `/docs`

## Acceptance criteria

- `task check` passes
- Both redirects tested