### PR TITLE
2.4: GET /linked-data/{source_name} — list features by source

### DIFF
--- a/src/nldi/controllers/linked_data.py
+++ b/src/nldi/controllers/linked_data.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from litestar import Controller, Response, get, head
 from litestar.exceptions import ClientException, HTTPException, NotFoundException
-from litestar.params import Dependency
+from litestar.params import Dependency, Parameter
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import get_base_url
@@ -98,12 +98,10 @@ class LinkedDataController(Controller):
         feature_repo: Annotated[FeatureRepository, Dependency(skip_validation=True)],
         flowline_repo: Annotated[FlowlineRepository, Dependency(skip_validation=True)],
         f: str = "",
-        limit: int = 0,
-        offset: int = 0,
+        limit: Annotated[int, Parameter(ge=0, description="Max features to return. 0 = no limit.")] = 0,
+        offset: Annotated[int, Parameter(ge=0, description="Number of features to skip.")] = 0,
     ) -> Response:
         """List all features for a source."""
-        if limit < 0 or offset < 0:
-            raise ClientException(detail="limit and offset must be non-negative integers.")
         base_url = get_base_url()
 
         if source_name.lower() == "comid":

--- a/src/nldi/controllers/linked_data.py
+++ b/src/nldi/controllers/linked_data.py
@@ -91,9 +91,66 @@ class LinkedDataController(Controller):
         _not_implemented()
 
     @get("/{source_name:str}", tags=["by_sourceid"])
-    async def list_features_by_source(self, source_name: str, f: str = "") -> None:
+    async def list_features_by_source(
+        self,
+        source_name: str,
+        source_repo: Annotated[CrawlerSourceRepository, Dependency(skip_validation=True)],
+        feature_repo: Annotated[FeatureRepository, Dependency(skip_validation=True)],
+        flowline_repo: Annotated[FlowlineRepository, Dependency(skip_validation=True)],
+        f: str = "",
+        limit: int = 0,
+        offset: int = 0,
+    ) -> Response:
         """List all features for a source."""
-        _not_implemented()
+        base_url = get_base_url()
+
+        if source_name.lower() == "comid":
+            items = await flowline_repo.list_all(limit=limit, offset=offset)
+            features = []
+            for fl in items:
+                nav_url = f"{base_url}/linked-data/comid/{fl.nhdplus_comid}/navigation"
+                features.append(
+                    Feature(
+                        geometry=None,
+                        properties={
+                            "identifier": str(fl.nhdplus_comid),
+                            "navigation": nav_url,
+                            "source": "comid",
+                            "sourceName": "NHDPlus comid",
+                            "comid": fl.nhdplus_comid,
+                        },
+                        id=fl.nhdplus_comid,
+                    )
+                )
+        else:
+            source = await source_repo.get_by_suffix(source_name)
+            if not source:
+                raise NotFoundException(detail=f"No such source: {source_name}")
+            items = await feature_repo.list_by_source(source_name, limit=limit, offset=offset)
+            features = []
+            for feat in items:
+                nav_url = f"{base_url}/linked-data/{source_name}/{feat.identifier}/navigation"
+                features.append(
+                    Feature(
+                        geometry=None,
+                        properties={
+                            "identifier": feat.identifier,
+                            "navigation": nav_url,
+                            "name": feat.name,
+                            "source": feat.source_suffix_proxy,
+                            "sourceName": feat.source_name_proxy,
+                            "comid": feat.comid if feat.comid else None,
+                            "type": feat.feature_type_proxy,
+                            "uri": feat.uri,
+                            "reachcode": feat.reachcode or None,
+                            "mainstem": feat.mainstem if feat.mainstem and feat.mainstem != "NA" else None,
+                        },
+                        id=feat.identifier,
+                    )
+                )
+
+        fc = FeatureCollection(features=features)
+        return Response(content=fc, status_code=200, media_type=MediaType.GEOJSON)
 
     @get("/{source_name:str}/{identifier:str}", tags=["by_sourceid"])
     async def get_feature_by_identifier(

--- a/src/nldi/controllers/linked_data.py
+++ b/src/nldi/controllers/linked_data.py
@@ -102,6 +102,8 @@ class LinkedDataController(Controller):
         offset: int = 0,
     ) -> Response:
         """List all features for a source."""
+        if limit < 0 or offset < 0:
+            raise ClientException(detail="limit and offset must be non-negative integers.")
         base_url = get_base_url()
 
         if source_name.lower() == "comid":

--- a/src/nldi/db/repos.py
+++ b/src/nldi/db/repos.py
@@ -45,12 +45,32 @@ class FeatureRepository(SQLAlchemyAsyncRepository[FeatureSourceModel]):
             ),
         )
 
+    async def list_by_source(self, source_suffix: str, limit: int = 0, offset: int = 0) -> list[FeatureSourceModel]:
+        """List features for a source, with optional pagination."""
+        stmt = (
+            sqlalchemy.select(FeatureSourceModel)
+            .join(CrawlerSourceModel, FeatureSourceModel.crawler_source_id == CrawlerSourceModel.crawler_source_id)
+            .where(sqlalchemy.func.lower(CrawlerSourceModel.source_suffix) == source_suffix.lower())
+            .order_by(FeatureSourceModel.identifier)
+            .offset(offset)
+        )
+        if limit > 0:
+            stmt = stmt.limit(limit)
+        return list(await self.list(statement=stmt))
+
 
 class FlowlineRepository(SQLAlchemyAsyncRepository[FlowlineModel]):
     """Repository for flowline lookups."""
 
     model_type = FlowlineModel
     id_attribute = "nhdplus_comid"
+
+    async def list_all(self, limit: int = 0, offset: int = 0) -> list[FlowlineModel]:
+        """List flowlines with optional pagination."""
+        stmt = sqlalchemy.select(FlowlineModel).order_by(FlowlineModel.nhdplus_comid).offset(offset)
+        if limit > 0:
+            stmt = stmt.limit(limit)
+        return list(await self.list(statement=stmt))
 
 
 class CatchmentRepository(SQLAlchemyAsyncRepository[CatchmentModel]):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -81,6 +81,14 @@ class FakeFeatureRepository:
                 return f
         return None
 
+    async def list_by_source(self, source_suffix: str, limit: int = 0, offset: int = 0) -> list:
+        """List features for a source with pagination."""
+        results = [f for f in self._features if f.source_suffix_proxy.lower() == source_suffix.lower()]
+        results = results[offset:]
+        if limit > 0:
+            results = results[:limit]
+        return results
+
 
 class FakeFlowlineRepository:
     """Fake FlowlineRepository for unit tests."""
@@ -104,6 +112,13 @@ class FakeFlowlineRepository:
             if f.nhdplus_comid == int(comid):
                 return f
         return None
+
+    async def list_all(self, limit: int = 0, offset: int = 0) -> list:
+        """List flowlines with pagination."""
+        results = self._flowlines[offset:]
+        if limit > 0:
+            results = results[:limit]
+        return results
 
 
 @pytest.fixture()

--- a/tests/unit/test_list_features.py
+++ b/tests/unit/test_list_features.py
@@ -1,0 +1,76 @@
+"""Unit tests for GET /linked-data/{source_name} (list features by source)."""
+
+import os
+
+from litestar.di import Provide
+from litestar.testing import TestClient
+
+from nldi.asgi import create_app
+
+
+def _app_with_fakes(source_repo, feature_repo, flowline_repo):
+    os.environ.setdefault("NLDI_BASE_URL", "https://test.example.com/nldi")
+    return create_app(dependencies={
+        "source_repo": Provide(lambda: source_repo, sync_to_thread=False),
+        "feature_repo": Provide(lambda: feature_repo, sync_to_thread=False),
+        "flowline_repo": Provide(lambda: flowline_repo, sync_to_thread=False),
+    })
+
+
+class TestListFeatures:
+    def test_unknown_source_returns_404(self, fake_source_repo, fake_feature_repo, fake_flowline_repo):
+        app = _app_with_fakes(fake_source_repo([]), fake_feature_repo([]), fake_flowline_repo([]))
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/nosuch")
+            assert r.status_code == 404
+
+    def test_known_source_returns_feature_collection(
+        self, fake_source_repo, make_source, fake_feature_repo, make_feature, fake_flowline_repo
+    ):
+        app = _app_with_fakes(
+            fake_source_repo([make_source("wqp", "WQP")]),
+            fake_feature_repo([
+                make_feature("USGS-01", "wqp", "WQP", "Site 1", "https://example.com/1"),
+                make_feature("USGS-02", "wqp", "WQP", "Site 2", "https://example.com/2"),
+            ]),
+            fake_flowline_repo([]),
+        )
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/wqp")
+            assert r.status_code == 200
+            assert r.headers["content-type"] == "application/geo+json"
+            body = r.json()
+            assert body["type"] == "FeatureCollection"
+            assert len(body["features"]) == 2
+
+    def test_empty_source_returns_empty_collection(
+        self, fake_source_repo, make_source, fake_feature_repo, fake_flowline_repo
+    ):
+        app = _app_with_fakes(
+            fake_source_repo([make_source("wqp", "WQP")]),
+            fake_feature_repo([]),
+            fake_flowline_repo([]),
+        )
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/wqp")
+            assert r.status_code == 200
+            body = r.json()
+            assert body["type"] == "FeatureCollection"
+            assert len(body["features"]) == 0
+
+    def test_pagination_limits_results(
+        self, fake_source_repo, make_source, fake_feature_repo, make_feature, fake_flowline_repo
+    ):
+        app = _app_with_fakes(
+            fake_source_repo([make_source("wqp", "WQP")]),
+            fake_feature_repo([
+                make_feature("USGS-01", "wqp", "WQP", "Site 1", "https://example.com/1"),
+                make_feature("USGS-02", "wqp", "WQP", "Site 2", "https://example.com/2"),
+                make_feature("USGS-03", "wqp", "WQP", "Site 3", "https://example.com/3"),
+            ]),
+            fake_flowline_repo([]),
+        )
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/wqp?limit=2")
+            body = r.json()
+            assert len(body["features"]) == 2

--- a/tests/unit/test_list_features.py
+++ b/tests/unit/test_list_features.py
@@ -74,3 +74,13 @@ class TestListFeatures:
             r = client.get("/api/nldi/linked-data/wqp?limit=2")
             body = r.json()
             assert len(body["features"]) == 2
+
+    def test_negative_limit_returns_400(self, fake_source_repo, make_source, fake_feature_repo, fake_flowline_repo):
+        app = _app_with_fakes(
+            fake_source_repo([make_source("wqp", "WQP")]),
+            fake_feature_repo([]),
+            fake_flowline_repo([]),
+        )
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/wqp?limit=-1")
+            assert r.status_code == 400

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -30,7 +30,6 @@ import pytest
 STUB_PATHS = [
     "/api/nldi/linked-data/hydrolocation?coords=POINT(-89 43)",
     "/api/nldi/linked-data/comid/position?coords=POINT(-89 43)",
-    "/api/nldi/linked-data/wqp",
     "/api/nldi/linked-data/wqp/USGS-01/basin",
     "/api/nldi/linked-data/wqp/USGS-01/navigation",
     "/api/nldi/linked-data/wqp/USGS-01/navigation/UM",


### PR DESCRIPTION
## What

Phase 2, PR 4. See [spec](docs/specs/pr-2.4-list-features.md). Reuses Feature-building pattern from 2.3, adds pagination.

## Plan

1. `FeatureRepository.list_by_source(suffix, limit, offset)`
2. `FlowlineRepository.list_all(limit, offset)` for comid source
3. Handler: validate source, query features, build FeatureCollection
4. Pagination: `limit` (default 0 = no limit) and `offset` (default 0)
5. Fake repos + unit tests
6. Integration test

## TDD behaviors

- [ ] Unknown source → 404
- [ ] Known source → FeatureCollection
- [ ] Empty source → empty FeatureCollection
- [ ] Pagination limits results
- [ ] Default (no limit) returns all
- [ ] Content-Type is `application/geo+json`
- [ ] Integration: real query against testcontainers