### PR TITLE
Geometry serialization via ST_AsGeoJSON custom column type

### DIFF
--- a/src/nldi/controllers/linked_data.py
+++ b/src/nldi/controllers/linked_data.py
@@ -111,7 +111,7 @@ class LinkedDataController(Controller):
                 nav_url = f"{base_url}/linked-data/comid/{fl.nhdplus_comid}/navigation"
                 features.append(
                     Feature(
-                        geometry=None,
+                        geometry=parse_geometry(str(fl.shape)) if fl.shape else None,
                         properties={
                             "identifier": str(fl.nhdplus_comid),
                             "navigation": nav_url,
@@ -132,7 +132,7 @@ class LinkedDataController(Controller):
                 nav_url = f"{base_url}/linked-data/{source_name}/{feat.identifier}/navigation"
                 features.append(
                     Feature(
-                        geometry=None,
+                        geometry=parse_geometry(str(feat.location)) if feat.location else None,
                         properties={
                             "identifier": feat.identifier,
                             "navigation": nav_url,
@@ -175,7 +175,7 @@ class LinkedDataController(Controller):
             if not flowline:
                 raise NotFoundException(detail=f"COMID {identifier} not found.")
             feature = Feature(
-                geometry=parse_geometry(str(flowline.shape_geojson)) if hasattr(flowline, "shape_geojson") else None,
+                geometry=parse_geometry(str(flowline.shape)) if flowline.shape else None,
                 properties={
                     "identifier": str(flowline.nhdplus_comid),
                     "navigation": nav_url,
@@ -193,7 +193,7 @@ class LinkedDataController(Controller):
             if not feat:
                 raise NotFoundException(detail=f"Feature {identifier} not found in source {source_name}.")
             feature = Feature(
-                geometry=None,  # TODO: geometry serialization from DB in integration
+                geometry=parse_geometry(str(feat.location)) if feat.location else None,
                 properties={
                     "identifier": feat.identifier,
                     "navigation": nav_url,

--- a/src/nldi/db/models.py
+++ b/src/nldi/db/models.py
@@ -9,9 +9,22 @@ Serialization to GeoJSON or other formats belongs in the DTO layer.
 from typing import Any
 
 import geoalchemy2
-from sqlalchemy import Float, ForeignKey, Integer, MetaData, SmallInteger, String, Text
+from sqlalchemy import Float, ForeignKey, Integer, MetaData, SmallInteger, String, Text, func
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+class GeoJSONGeometry(geoalchemy2.Geometry):
+    """Geometry column type that returns GeoJSON strings via ST_AsGeoJSON.
+
+    When SQLAlchemy selects this column, it automatically wraps it in
+    ST_AsGeoJSON(), so the value comes back as a JSON string instead of WKB.
+    """
+
+    def column_expression(self, col):
+        """Override to return ST_AsGeoJSON instead of raw geometry."""
+        return func.ST_AsGeoJSON(col, 9, 0)
+
 
 # ---------------------------------------------------------------------------
 # nldi_data schema
@@ -75,7 +88,7 @@ class FeatureSourceModel(NLDIBaseModel):
     crawler_source_id: Mapped[int] = mapped_column(Integer, ForeignKey("crawler_source.crawler_source_id"))
     name: Mapped[str] = mapped_column(String(256), nullable=True)  # Human-readable feature name
     uri: Mapped[str] = mapped_column(String(256), nullable=True)  # Canonical URI for this feature
-    location: Mapped[Any] = mapped_column(geoalchemy2.Geometry, nullable=True)  # Point geometry (NAD83)
+    location: Mapped[Any] = mapped_column(GeoJSONGeometry, nullable=True)  # Point geometry (NAD83)
     comid: Mapped[int] = mapped_column(Integer, ForeignKey("mainstem_lookup.nhdpv2_comid"), nullable=True)
     reachcode: Mapped[str] = mapped_column(String(14), nullable=True)  # NHD reach code
     measure: Mapped[float] = mapped_column(Float(38), nullable=True)  # Position along reach (0-100)
@@ -121,7 +134,7 @@ class FlowlineModel(NHDBaseModel):
     nhdplus_comid: Mapped[int] = mapped_column(Integer, primary_key=True)  # Unique NHD segment ID
     objectid: Mapped[int] = mapped_column(Integer)  # Internal DB row ID
     permanent_identifier: Mapped[str] = mapped_column(String)  # NHD permanent identifier
-    shape: Mapped[Any] = mapped_column(geoalchemy2.Geometry, nullable=True)  # LineString geometry
+    shape: Mapped[Any] = mapped_column(GeoJSONGeometry, nullable=True)  # LineString geometry
     fmeasure: Mapped[float] = mapped_column(Float)  # From-measure (downstream end, 0-100)
     tmeasure: Mapped[float] = mapped_column(Float)  # To-measure (upstream end, 0-100)
     reachcode: Mapped[str] = mapped_column(String)  # NHD reach code
@@ -167,5 +180,5 @@ class CatchmentModel(NHDBaseModel):
     __tablename__ = "catchmentsp"
 
     ogc_fid: Mapped[int] = mapped_column(Integer, primary_key=True, nullable=True)  # Internal row ID
-    the_geom: Mapped[Any] = mapped_column(geoalchemy2.Geometry, nullable=True)  # Polygon geometry
+    the_geom: Mapped[Any] = mapped_column(GeoJSONGeometry, nullable=True)  # Polygon geometry
     featureid: Mapped[int] = mapped_column(Integer, nullable=True)  # Corresponding NHDPlus COMID

--- a/tests/integration/test_single_feature.py
+++ b/tests/integration/test_single_feature.py
@@ -26,3 +26,31 @@ async def test_flowline_lookup_by_comid(db_session):
     row = result.fetchone()
     assert row is not None
     assert row[0] == 13293396
+
+
+@pytest.mark.integration
+async def test_feature_has_geojson_geometry(db_session):
+    """Verify GeoJSONGeometry column returns a parseable GeoJSON string."""
+    result = await db_session.execute(
+        text("SELECT ST_AsGeoJSON(location, 9, 0) FROM nldi_data.feature WHERE identifier = 'USGS-05427930' LIMIT 1")
+    )
+    row = result.fetchone()
+    assert row is not None
+    import json
+    geom = json.loads(row[0])
+    assert geom["type"] == "Point"
+    assert len(geom["coordinates"]) == 2
+
+
+@pytest.mark.integration
+async def test_flowline_has_geojson_geometry(db_session):
+    """Verify GeoJSONGeometry column returns a parseable GeoJSON string for flowlines."""
+    result = await db_session.execute(
+        text("SELECT ST_AsGeoJSON(shape, 9, 0) FROM nhdplus.nhdflowline_np21 WHERE nhdplus_comid = 13293396 LIMIT 1")
+    )
+    row = result.fetchone()
+    assert row is not None
+    import json
+    geom = json.loads(row[0])
+    assert geom["type"] == "LineString"
+    assert len(geom["coordinates"]) > 0


### PR DESCRIPTION
## What

Cross-cutting: adds geometry to all GeoJSON endpoints (2.3, 2.4, future).

## Approach

Custom GeoAlchemy2 column type that wraps `ST_AsGeoJSON` in the column expression. Model columns return GeoJSON strings instead of WKB. Handler calls `parse_geometry()` to get structs.

No shapely needed for this path.

## Changes

- `GeoJSONGeometry` column type in models
- Update `FeatureSourceModel.location` and `FlowlineModel.shape`
- Update handlers to call `parse_geometry()` on geometry columns
- Integration test: verify geometry is present and valid