### PR TITLE
2.6+2.7: Navigation modes and navigation info

### DIFF
--- a/src/nldi/controllers/linked_data.py
+++ b/src/nldi/controllers/linked_data.py
@@ -253,14 +253,57 @@ class LinkedDataController(Controller):
         _not_implemented()
 
     @get("/{source_name:str}/{identifier:str}/navigation", tags=["by_sourceid"])
-    async def get_navigation_modes(self, source_name: str, identifier: str) -> None:
+    async def get_navigation_modes(
+        self,
+        source_name: str,
+        identifier: str,
+        source_repo: Annotated[CrawlerSourceRepository, Dependency(skip_validation=True)],
+    ) -> dict:
         """Return navigation mode URLs."""
-        _not_implemented()
+        base_url = get_base_url()
+        if source_name.lower() != "comid":
+            source = await source_repo.get_by_suffix(source_name)
+            if not source:
+                raise NotFoundException(detail=f"No such source: {source_name}")
+        nav_url = f"{base_url}/linked-data/{source_name}/{identifier}/navigation"
+        return {
+            "upstreamMain": f"{nav_url}/UM",
+            "upstreamTributaries": f"{nav_url}/UT",
+            "downstreamMain": f"{nav_url}/DM",
+            "downstreamDiversions": f"{nav_url}/DD",
+        }
 
     @get("/{source_name:str}/{identifier:str}/navigation/{nav_mode:str}", tags=["by_sourceid"])
-    async def get_navigation_info(self, source_name: str, identifier: str, nav_mode: str) -> None:
+    async def get_navigation_info(
+        self,
+        source_name: str,
+        identifier: str,
+        nav_mode: str,
+        source_repo: Annotated[CrawlerSourceRepository, Dependency(skip_validation=True)],
+    ) -> list[dict]:
         """List data sources available for navigation."""
-        _not_implemented()
+        valid_modes = {"UM", "UT", "DM", "DD"}
+        if nav_mode.upper() not in valid_modes:
+            raise ClientException(
+                detail=f"Invalid navigation mode: {nav_mode}. Must be one of {', '.join(sorted(valid_modes))}."
+            )
+        base_url = get_base_url()
+        if source_name.lower() != "comid":
+            source = await source_repo.get_by_suffix(source_name)
+            if not source:
+                raise NotFoundException(detail=f"No such source: {source_name}")
+        nav_url = f"{base_url}/linked-data/{source_name}/{identifier}/navigation/{nav_mode}"
+        result = [{"source": "Flowlines", "sourceName": "NHDPlus flowlines", "features": f"{nav_url}/flowlines"}]
+        sources = await source_repo.list()
+        for s in sources:
+            result.append(
+                {
+                    "source": s.source_suffix,
+                    "sourceName": s.source_name,
+                    "features": f"{nav_url}/{s.source_suffix.lower()}",
+                }
+            )
+        return result
 
     @get("/{source_name:str}/{identifier:str}/navigation/{nav_mode:str}/flowlines", tags=["by_sourceid"])
     async def get_flowline_navigation(self, source_name: str, identifier: str, nav_mode: str) -> None:

--- a/tests/unit/test_navigation.py
+++ b/tests/unit/test_navigation.py
@@ -1,0 +1,64 @@
+"""Unit tests for navigation modes and navigation info endpoints."""
+
+import os
+
+from litestar.di import Provide
+from litestar.testing import TestClient
+
+from nldi.asgi import create_app
+
+
+def _app_with_fakes(source_repo):
+    os.environ.setdefault("NLDI_BASE_URL", "https://test.example.com/nldi")
+    return create_app(dependencies={
+        "source_repo": Provide(lambda: source_repo, sync_to_thread=False),
+    })
+
+
+class TestNavigationModes:
+    def test_returns_four_modes(self, fake_source_repo, make_source):
+        app = _app_with_fakes(fake_source_repo([make_source("wqp", "WQP")]))
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/wqp/USGS-01/navigation")
+            assert r.status_code == 200
+            body = r.json()
+            assert "upstreamMain" in body
+            assert "upstreamTributaries" in body
+            assert "downstreamMain" in body
+            assert "downstreamDiversions" in body
+            assert body["upstreamMain"].endswith("/navigation/UM")
+
+    def test_unknown_source_returns_404(self, fake_source_repo):
+        app = _app_with_fakes(fake_source_repo([]))
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/nosuch/ABC/navigation")
+            assert r.status_code == 404
+
+    def test_comid_source_skips_validation(self, fake_source_repo):
+        app = _app_with_fakes(fake_source_repo([]))
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/comid/123/navigation")
+            assert r.status_code == 200
+
+
+class TestNavigationInfo:
+    def test_returns_sources_with_flowlines_first(self, fake_source_repo, make_source):
+        app = _app_with_fakes(fake_source_repo([make_source("wqp", "WQP"), make_source("nwissite", "NWIS")]))
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/wqp/USGS-01/navigation/UM")
+            assert r.status_code == 200
+            body = r.json()
+            assert body[0]["source"] == "Flowlines"
+            assert len(body) == 3  # flowlines + 2 sources
+
+    def test_invalid_nav_mode_returns_400(self, fake_source_repo, make_source):
+        app = _app_with_fakes(fake_source_repo([make_source("wqp", "WQP")]))
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/wqp/USGS-01/navigation/BOGUS")
+            assert r.status_code == 400
+
+    def test_unknown_source_returns_404(self, fake_source_repo):
+        app = _app_with_fakes(fake_source_repo([]))
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/nosuch/ABC/navigation/UM")
+            assert r.status_code == 404

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -30,8 +30,6 @@ import pytest
 STUB_PATHS = [
     "/api/nldi/linked-data/hydrolocation?coords=POINT(-89 43)",
     "/api/nldi/linked-data/wqp/USGS-01/basin",
-    "/api/nldi/linked-data/wqp/USGS-01/navigation",
-    "/api/nldi/linked-data/wqp/USGS-01/navigation/UM",
     "/api/nldi/linked-data/wqp/USGS-01/navigation/UM/flowlines",
     "/api/nldi/linked-data/wqp/USGS-01/navigation/UM/nwissite",
 ]


### PR DESCRIPTION
## What

Two simple JSON endpoints combined into one PR.

### 2.6: GET /{source}/{id}/navigation
Returns navigation mode URLs (UM, UT, DM, DD).

### 2.7: GET /{source}/{id}/navigation/{nav_mode}
Returns data sources available for a nav mode. Validates nav_mode.

## TDD behaviors

- [ ] Nav modes returns dict with 4 mode URLs
- [ ] Nav info returns list of data sources with flowlines first
- [ ] Invalid nav_mode → 400
- [ ] Unknown source → 404