### PR TITLE
3.1: Navigation infrastructure + DM flowline navigation

### DIFF
--- a/src/nldi/controllers/linked_data.py
+++ b/src/nldi/controllers/linked_data.py
@@ -10,6 +10,8 @@ from litestar.params import Dependency, Parameter
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import get_base_url
+from ..db.navigation import NAV_DIST_DEFAULTS, NavigationModes
+from ..db.navigation import dm as dm_query
 from ..db.repos import CatchmentRepository, CrawlerSourceRepository, FeatureRepository, FlowlineRepository
 from ..dto import DataSource
 from ..geojson import Feature, FeatureCollection, parse_geometry
@@ -53,6 +55,33 @@ async def provide_flowline_repo(db_session: AsyncSession) -> FlowlineRepository:
 async def provide_catchment_repo(db_session: AsyncSession) -> CatchmentRepository:
     """Provide CatchmentRepository via DI."""
     return CatchmentRepository(session=db_session)
+
+
+async def _resolve_comid(source_name, identifier, source_repo, feature_repo, flowline_repo) -> int:
+    """Resolve a source/identifier pair to a COMID."""
+    if source_name.lower() == "comid":
+        try:
+            return int(identifier)
+        except ValueError as e:
+            raise ClientException(detail=f"Not a valid comid: {identifier}") from e
+    source = await source_repo.get_by_suffix(source_name)
+    if not source:
+        raise NotFoundException(detail=f"No such source: {source_name}")
+    feat = await feature_repo.feature_lookup(source_name, identifier)
+    if not feat:
+        raise NotFoundException(detail=f"Feature {identifier} not found in source {source_name}.")
+    if not feat.comid:
+        raise NotFoundException(detail=f"No comid for feature {identifier} in source {source_name}.")
+    return int(feat.comid)
+
+
+def _build_nav_flowline_feature(flowline) -> Feature:
+    """Build a minimal GeoJSON Feature for navigation flowline results."""
+    return Feature(
+        geometry=parse_geometry(str(flowline.shape)) if flowline.shape else None,
+        properties={"nhdplus_comid": flowline.nhdplus_comid},
+        id=flowline.nhdplus_comid,
+    )
 
 
 def _build_comid_feature(flowline, base_url: str) -> Feature:
@@ -270,9 +299,34 @@ class LinkedDataController(Controller):
         return result
 
     @get("/{source_name:str}/{identifier:str}/navigation/{nav_mode:str}/flowlines", tags=["by_sourceid"])
-    async def get_flowline_navigation(self, source_name: str, identifier: str, nav_mode: str) -> None:
-        """Navigate flowlines."""
-        _not_implemented()
+    async def get_flowline_navigation(
+        self,
+        source_name: str,
+        identifier: str,
+        nav_mode: str,
+        source_repo: Annotated[CrawlerSourceRepository, Dependency(skip_validation=True)],
+        feature_repo: Annotated[FeatureRepository, Dependency(skip_validation=True)],
+        flowline_repo: Annotated[FlowlineRepository, Dependency(skip_validation=True)],
+        distance: float | None = None,
+    ) -> Response:
+        """Navigate flowlines from a starting point."""
+        mode_upper = nav_mode.upper()
+        if mode_upper not in NavigationModes.__members__:
+            raise ClientException(
+                detail=f"Invalid navigation mode: {nav_mode}. Must be one of {', '.join(NavigationModes)}."
+            )
+
+        if mode_upper != "DM":
+            _not_implemented()  # DD, UM, UT in PR 3.2
+
+        comid = await _resolve_comid(source_name, identifier, source_repo, feature_repo, flowline_repo)
+        dist = distance if distance is not None else NAV_DIST_DEFAULTS.get(NavigationModes(mode_upper), 100)
+
+        nav_query = dm_query(comid=comid, distance=dist)
+        flowlines = await flowline_repo.from_nav_query(nav_query)
+        features = [_build_nav_flowline_feature(fl) for fl in flowlines]
+
+        return Response(content=FeatureCollection(features=features), status_code=200, media_type=MediaType.GEOJSON)
 
     @get("/{source_name:str}/{identifier:str}/navigation/{nav_mode:str}/{data_source:str}", tags=["by_sourceid"])
     async def get_feature_navigation(self, source_name: str, identifier: str, nav_mode: str, data_source: str) -> None:

--- a/src/nldi/db/navigation.py
+++ b/src/nldi/db/navigation.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2024-present USGS
+"""Navigation query builders — recursive CTEs for network traversal.
+
+Each function returns a SQLAlchemy Select that produces a list of COMIDs
+along the navigation path. The query must be executed against the database
+and joined to FlowlineModel or FeatureSourceModel to produce results.
+
+See docs/implementation-notes.md for readability notes.
+"""
+
+from enum import StrEnum
+
+from sqlalchemy import Select, and_, bindparam, select
+from sqlalchemy.orm import aliased
+
+from .models import FlowlineVAAModel
+
+COASTAL_FCODE = 56600
+
+
+class NavigationModes(StrEnum):
+    """Valid navigation modes."""
+
+    DM = "DM"
+    DD = "DD"
+    UM = "UM"
+    UT = "UT"
+
+
+NAV_DIST_DEFAULTS = {
+    NavigationModes.DM: 100_000,
+    NavigationModes.UM: 100_000,
+    NavigationModes.UT: 100,
+    NavigationModes.DD: 100,
+}
+
+
+def dm(comid: int, distance: float, coastal_fcode: int = COASTAL_FCODE) -> Select:
+    """Downstream Main navigation CTE.
+
+    Walks downstream following the main channel (dnhydroseq) on the same
+    terminal path. Stops when distance is exceeded or coastal fcode is reached.
+    """
+    nav = (
+        select(
+            FlowlineVAAModel.comid,
+            FlowlineVAAModel.terminalpathid,
+            FlowlineVAAModel.dnhydroseq,
+            FlowlineVAAModel.fcode,
+            (FlowlineVAAModel.pathlength + FlowlineVAAModel.lengthkm - bindparam("distance")).label("stoplength"),
+        )
+        .where(FlowlineVAAModel.comid == bindparam("comid"))
+        .cte("nav", recursive=True)
+    )
+
+    vaa = aliased(FlowlineVAAModel, name="vaa")
+    nav_dm = nav.union(
+        select(
+            vaa.comid,
+            vaa.terminalpathid,
+            vaa.dnhydroseq,
+            vaa.fcode,
+            nav.c.stoplength,
+        ).where(
+            and_(
+                vaa.hydroseq == nav.c.dnhydroseq,
+                vaa.terminalpathid == nav.c.terminalpathid,
+                vaa.fcode != bindparam("coastal_fcode"),
+                vaa.pathlength + vaa.lengthkm >= nav.c.stoplength,
+            )
+        )
+    )
+
+    return (
+        select(nav_dm.c.comid).select_from(nav_dm).params(comid=comid, distance=distance, coastal_fcode=coastal_fcode)
+    )

--- a/src/nldi/db/repos.py
+++ b/src/nldi/db/repos.py
@@ -73,6 +73,12 @@ class FlowlineRepository(SQLAlchemyAsyncRepository[FlowlineModel]):
             stmt = stmt.limit(limit)
         return list(await self.list(statement=stmt))
 
+    async def from_nav_query(self, nav_query: sqlalchemy.sql.Select) -> list[FlowlineModel]:
+        """Execute a navigation CTE and join to flowlines."""
+        subq = nav_query.subquery()
+        stmt = sqlalchemy.select(FlowlineModel).join(subq, FlowlineModel.nhdplus_comid == subq.c.comid)
+        return list(await self.list(statement=stmt))
+
 
 class CatchmentRepository(SQLAlchemyAsyncRepository[CatchmentModel]):
     """Repository for catchment lookups."""

--- a/tests/integration/test_navigation.py
+++ b/tests/integration/test_navigation.py
@@ -1,0 +1,20 @@
+"""Integration tests for flowline navigation."""
+
+import pytest
+from sqlalchemy import text
+
+
+@pytest.mark.integration
+async def test_dm_navigation_returns_flowlines(db_session):
+    """DM navigation from a known comid should return multiple flowlines."""
+    from nldi.db.navigation import dm
+    from nldi.db.models import FlowlineModel
+    from sqlalchemy import select
+
+    nav_query = dm(comid=13293396, distance=10)
+    subq = nav_query.subquery()
+    stmt = select(FlowlineModel.nhdplus_comid).join(subq, FlowlineModel.nhdplus_comid == subq.c.comid)
+    result = await db_session.execute(stmt)
+    comids = [row[0] for row in result]
+    assert len(comids) > 0
+    assert 13293396 in comids  # starting comid should be in results

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -120,6 +120,10 @@ class FakeFlowlineRepository:
             results = results[:limit]
         return results
 
+    async def from_nav_query(self, nav_query) -> list:
+        """Fake: return all flowlines (ignores nav query)."""
+        return self._flowlines
+
 
 class FakeCatchmentModel:
     """Minimal stand-in for CatchmentModel."""

--- a/tests/unit/test_flowline_nav.py
+++ b/tests/unit/test_flowline_nav.py
@@ -1,0 +1,53 @@
+"""Unit tests for flowline navigation endpoint."""
+
+import os
+
+from litestar.di import Provide
+from litestar.testing import TestClient
+
+from nldi.asgi import create_app
+
+
+def _app_with_fakes(source_repo, feature_repo, flowline_repo):
+    os.environ.setdefault("NLDI_BASE_URL", "https://test.example.com/nldi")
+    return create_app(dependencies={
+        "source_repo": Provide(lambda: source_repo, sync_to_thread=False),
+        "feature_repo": Provide(lambda: feature_repo, sync_to_thread=False),
+        "flowline_repo": Provide(lambda: flowline_repo, sync_to_thread=False),
+    })
+
+
+class TestFlowlineNavigation:
+    def test_dm_returns_feature_collection(
+        self, fake_source_repo, fake_feature_repo, fake_flowline_repo, make_flowline
+    ):
+        app = _app_with_fakes(
+            fake_source_repo([]),
+            fake_feature_repo([]),
+            fake_flowline_repo([make_flowline(13293396), make_flowline(13293400)]),
+        )
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/comid/13293396/navigation/DM/flowlines?distance=10")
+            assert r.status_code == 200
+            body = r.json()
+            assert body["type"] == "FeatureCollection"
+            assert len(body["features"]) == 2
+            assert body["features"][0]["properties"]["nhdplus_comid"] == 13293396
+
+    def test_invalid_mode_returns_400(self, fake_source_repo, fake_feature_repo, fake_flowline_repo):
+        app = _app_with_fakes(fake_source_repo([]), fake_feature_repo([]), fake_flowline_repo([]))
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/comid/123/navigation/BOGUS/flowlines?distance=10")
+            assert r.status_code == 400
+
+    def test_unsupported_mode_returns_501(self, fake_source_repo, fake_feature_repo, fake_flowline_repo):
+        app = _app_with_fakes(fake_source_repo([]), fake_feature_repo([]), fake_flowline_repo([]))
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/comid/123/navigation/UM/flowlines?distance=10")
+            assert r.status_code == 501
+
+    def test_invalid_comid_returns_400(self, fake_source_repo, fake_feature_repo, fake_flowline_repo):
+        app = _app_with_fakes(fake_source_repo([]), fake_feature_repo([]), fake_flowline_repo([]))
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/comid/notanumber/navigation/DM/flowlines?distance=10")
+            assert r.status_code == 400

--- a/tests/unit/test_navigation_query.py
+++ b/tests/unit/test_navigation_query.py
@@ -1,0 +1,19 @@
+"""Unit tests for navigation query builder."""
+
+from sqlalchemy.sql import Select
+
+
+def test_navigation_modes_import():
+    from nldi.db.navigation import NavigationModes
+
+    assert "DM" in NavigationModes.__members__
+    assert "DD" in NavigationModes.__members__
+    assert "UM" in NavigationModes.__members__
+    assert "UT" in NavigationModes.__members__
+
+
+def test_dm_returns_select():
+    from nldi.db.navigation import dm
+
+    query = dm(comid=13293396, distance=10)
+    assert isinstance(query, Select)

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -30,7 +30,6 @@ import pytest
 STUB_PATHS = [
     "/api/nldi/linked-data/hydrolocation?coords=POINT(-89 43)",
     "/api/nldi/linked-data/wqp/USGS-01/basin",
-    "/api/nldi/linked-data/wqp/USGS-01/navigation/UM/flowlines",
     "/api/nldi/linked-data/wqp/USGS-01/navigation/UM/nwissite",
 ]
 


### PR DESCRIPTION
## What

Phase 3, PR 1. See [spec](docs/specs/pr-3.1-navigation-dm.md). Establishes navigation CTE pattern with DM mode.

## Plan

1. `src/nldi/db/navigation.py` — NavigationModes enum, NAV_DIST_DEFAULTS, dm() CTE
2. Resolve starting comid helper
3. `FlowlineRepository.from_nav_query()` — execute CTE + join flowlines
4. Handler: validate mode, resolve comid, nav query, return FeatureCollection
5. Fakes + unit tests
6. Integration test: DM from known comid

## TDD behaviors

- [ ] NavigationModes enum imports
- [ ] dm() produces a valid Select
- [ ] Resolve comid from source/identifier
- [ ] DM flowlines returns FeatureCollection
- [ ] Invalid/unsupported mode returns error
- [ ] Integration: real DM query returns flowlines