### PR TITLE
3.3: Feature navigation by data source

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -43,11 +43,14 @@ One PR per endpoint or small logical group. Each PR includes integration tests a
 
 The heavy path. Port SQL queries from pre-refactor, apply resource discipline (one session, release before streaming).
 
-| PR | Description | Depends on | Acceptance |
-| --- | --- | --- | --- |
-| 3.1 | Navigation query builder — CTE logic for UM, UT, DM, DD (ported from `NavigationService`) | 2.1 | Unit tests for query construction, integration tests for results |
-| 3.2 | `GET .../navigation/{nav_mode}/flowlines` — flowline navigation | 3.1 | Parity, distance/trim/excludeGeometry params work |
-| 3.3 | `GET .../navigation/{nav_mode}/{data_source}` — feature navigation | 3.1 | Parity, distance/excludeGeometry params work |
+| PR | Description | Status |
+| --- | --- | --- |
+| ~~3.1~~ | Navigation infrastructure + DM CTE, resolve comid, flowline nav handler | ✅ #172 |
+| ~~3.2~~ | DD, UM, UT modes + navigation_query dispatcher | ✅ #173 |
+| ~~3.3~~ | Feature navigation by data source | ✅ #174 |
+| 3.4 | Trim start/tolerance on flowline navigation (ST_LineSubstring) | 3.2 |
+| 3.5 | excludeGeometry parameter on navigation endpoints | 3.2 |
+| 3.6 | OpenAPI documentation polish pass | 3.3 |
 
 ## Phase 4: External services
 

--- a/src/nldi/controllers/linked_data.py
+++ b/src/nldi/controllers/linked_data.py
@@ -325,6 +325,30 @@ class LinkedDataController(Controller):
         return Response(content=FeatureCollection(features=features), status_code=200, media_type=MediaType.GEOJSON)
 
     @get("/{source_name:str}/{identifier:str}/navigation/{nav_mode:str}/{data_source:str}", tags=["by_sourceid"])
-    async def get_feature_navigation(self, source_name: str, identifier: str, nav_mode: str, data_source: str) -> None:
+    async def get_feature_navigation(
+        self,
+        source_name: str,
+        identifier: str,
+        nav_mode: str,
+        data_source: str,
+        source_repo: Annotated[CrawlerSourceRepository, Dependency(skip_validation=True)],
+        feature_repo: Annotated[FeatureRepository, Dependency(skip_validation=True)],
+        flowline_repo: Annotated[FlowlineRepository, Dependency(skip_validation=True)],
+        distance: float | None = None,
+    ) -> Response:
         """Navigate features of a data source."""
-        _not_implemented()
+        mode_upper = nav_mode.upper()
+        if mode_upper not in NavigationModes.__members__:
+            raise ClientException(
+                detail=f"Invalid navigation mode: {nav_mode}. Must be one of {', '.join(NavigationModes)}."
+            )
+
+        comid = await _resolve_comid(source_name, identifier, source_repo, feature_repo, flowline_repo)
+        dist = distance if distance is not None else NAV_DIST_DEFAULTS.get(NavigationModes(mode_upper), 100)
+        base_url = get_base_url()
+
+        nav_q = navigation_query(mode_upper, comid=comid, distance=dist)
+        feats = await feature_repo.from_nav_query(data_source, nav_q)
+        features = [_build_source_feature(f, base_url, data_source) for f in feats]
+
+        return Response(content=FeatureCollection(features=features), status_code=200, media_type=MediaType.GEOJSON)

--- a/src/nldi/db/repos.py
+++ b/src/nldi/db/repos.py
@@ -59,6 +59,17 @@ class FeatureRepository(SQLAlchemyAsyncRepository[FeatureSourceModel]):
             stmt = stmt.limit(limit)
         return list(await self.list(statement=stmt))
 
+    async def from_nav_query(self, data_source: str, nav_query: sqlalchemy.sql.Select) -> list[FeatureSourceModel]:
+        """Execute a navigation CTE and join to features filtered by data source."""
+        subq = nav_query.subquery()
+        stmt = (
+            sqlalchemy.select(FeatureSourceModel)
+            .join(CrawlerSourceModel, FeatureSourceModel.crawler_source_id == CrawlerSourceModel.crawler_source_id)
+            .join(subq, FeatureSourceModel.comid == subq.c.comid)
+            .where(sqlalchemy.func.lower(CrawlerSourceModel.source_suffix) == data_source.lower())
+        )
+        return list(await self.list(statement=stmt))
+
 
 class FlowlineRepository(SQLAlchemyAsyncRepository[FlowlineModel]):
     """Repository for flowline lookups."""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -89,6 +89,10 @@ class FakeFeatureRepository:
             results = results[:limit]
         return results
 
+    async def from_nav_query(self, data_source: str, nav_query) -> list:
+        """Fake: return features matching data_source (ignores nav query)."""
+        return [f for f in self._features if f.source_suffix_proxy.lower() == data_source.lower()]
+
 
 class FakeFlowlineRepository:
     """Fake FlowlineRepository for unit tests."""

--- a/tests/unit/test_feature_nav.py
+++ b/tests/unit/test_feature_nav.py
@@ -1,0 +1,41 @@
+"""Unit tests for feature navigation by data source."""
+
+import os
+
+from litestar.di import Provide
+from litestar.testing import TestClient
+
+from nldi.asgi import create_app
+
+
+def _app_with_fakes(source_repo, feature_repo, flowline_repo):
+    os.environ.setdefault("NLDI_BASE_URL", "https://test.example.com/nldi")
+    return create_app(dependencies={
+        "source_repo": Provide(lambda: source_repo, sync_to_thread=False),
+        "feature_repo": Provide(lambda: feature_repo, sync_to_thread=False),
+        "flowline_repo": Provide(lambda: flowline_repo, sync_to_thread=False),
+    })
+
+
+class TestFeatureNavigation:
+    def test_returns_feature_collection(
+        self, fake_source_repo, fake_feature_repo, make_feature, fake_flowline_repo
+    ):
+        app = _app_with_fakes(
+            fake_source_repo([]),
+            fake_feature_repo([make_feature("USGS-01", "wqp", "WQP", "Site 1", "https://example.com/1")]),
+            fake_flowline_repo([]),
+        )
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/comid/123/navigation/DM/wqp?distance=10")
+            assert r.status_code == 200
+            body = r.json()
+            assert body["type"] == "FeatureCollection"
+            assert len(body["features"]) == 1
+            assert body["features"][0]["properties"]["source"] == "wqp"
+
+    def test_invalid_mode_returns_400(self, fake_source_repo, fake_feature_repo, fake_flowline_repo):
+        app = _app_with_fakes(fake_source_repo([]), fake_feature_repo([]), fake_flowline_repo([]))
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/comid/123/navigation/BOGUS/wqp?distance=10")
+            assert r.status_code == 400

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -30,7 +30,6 @@ import pytest
 STUB_PATHS = [
     "/api/nldi/linked-data/hydrolocation?coords=POINT(-89 43)",
     "/api/nldi/linked-data/wqp/USGS-01/basin",
-    "/api/nldi/linked-data/wqp/USGS-01/navigation/UM/nwissite",
 ]
 
 


### PR DESCRIPTION
## What

`GET /{source}/{id}/navigation/{nav_mode}/{data_source}` — navigate features of a data source along the network.

Same nav CTEs as 3.1/3.2, joined to FeatureSourceModel filtered by data_source.

## Plan

1. `FeatureRepository.from_nav_query(data_source, nav_select)` — join CTE to features
2. Handler: resolve comid, nav query, join features, return FeatureCollection
3. Unit + integration tests