### PR TITLE
3.4: Trim start on flowline navigation

### DIFF
--- a/src/nldi/controllers/linked_data.py
+++ b/src/nldi/controllers/linked_data.py
@@ -10,7 +10,7 @@ from litestar.params import Dependency, Parameter
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import get_base_url
-from ..db.navigation import NAV_DIST_DEFAULTS, NavigationModes, navigation_query
+from ..db.navigation import NAV_DIST_DEFAULTS, NavigationModes, navigation_query, trim_nav_query
 from ..db.repos import CatchmentRepository, CrawlerSourceRepository, FeatureRepository, FlowlineRepository
 from ..dto import DataSource
 from ..geojson import Feature, FeatureCollection, parse_geometry
@@ -307,6 +307,8 @@ class LinkedDataController(Controller):
         feature_repo: Annotated[FeatureRepository, Dependency(skip_validation=True)],
         flowline_repo: Annotated[FlowlineRepository, Dependency(skip_validation=True)],
         distance: float | None = None,
+        trim_start: Annotated[bool, Parameter(query="trimStart")] = False,
+        trim_tolerance: Annotated[float, Parameter(query="trimTolerance")] = 0.0,
     ) -> Response:
         """Navigate flowlines from a starting point."""
         mode_upper = nav_mode.upper()
@@ -315,12 +317,36 @@ class LinkedDataController(Controller):
                 detail=f"Invalid navigation mode: {nav_mode}. Must be one of {', '.join(NavigationModes)}."
             )
 
+        if trim_start and source_name.lower() == "comid":
+            raise ClientException(detail="Cannot use trimStart with comid source.")
+
         comid = await _resolve_comid(source_name, identifier, source_repo, feature_repo, flowline_repo)
         dist = distance if distance is not None else NAV_DIST_DEFAULTS.get(NavigationModes(mode_upper), 100)
 
         nav_q = navigation_query(mode_upper, comid=comid, distance=dist)
-        flowlines = await flowline_repo.from_nav_query(nav_q)
-        features = [_build_nav_flowline_feature(fl) for fl in flowlines]
+
+        if trim_start:
+            # Get the feature's measure for trimming
+            feat = await feature_repo.feature_lookup(source_name, identifier)
+            measure = float(feat.measure) if feat and feat.measure else 0.0
+            if not measure:
+                # Estimate measure if not available — for now, skip trimming
+                trim_start = False
+
+        if trim_start:
+            trim_q = trim_nav_query(mode_upper, comid, trim_tolerance or 0.0, measure)
+            results = await flowline_repo.from_trimmed_nav_query(nav_q, trim_q)
+            features = []
+            for fl, trimmed_geojson in results:
+                feature = Feature(
+                    geometry=parse_geometry(trimmed_geojson) if trimmed_geojson else None,
+                    properties={"nhdplus_comid": fl.nhdplus_comid},
+                    id=fl.nhdplus_comid,
+                )
+                features.append(feature)
+        else:
+            flowlines = await flowline_repo.from_nav_query(nav_q)
+            features = [_build_nav_flowline_feature(fl) for fl in flowlines]
 
         return Response(content=FeatureCollection(features=features), status_code=200, media_type=MediaType.GEOJSON)
 

--- a/src/nldi/db/navigation.py
+++ b/src/nldi/db/navigation.py
@@ -222,12 +222,14 @@ def trim_nav_query(nav_mode: str, comid: int, trim_tolerance: float, measure: fl
 
     if nav_mode.upper() in ("DM", "DD"):
         trimmed_geojson = func.ST_AsGeoJSON(func.ST_LineSubstring(FlowlineModel.shape, scaled_measure, 1), 9, 0)
+        should_trim = 100 - measure >= trim_tolerance
     else:
         trimmed_geojson = func.ST_AsGeoJSON(func.ST_LineSubstring(FlowlineModel.shape, 0, scaled_measure), 9, 0)
+        should_trim = measure >= trim_tolerance
 
     full_geojson = func.ST_AsGeoJSON(FlowlineModel.shape, 9, 0)
 
-    if 100 - measure >= trim_tolerance:
+    if should_trim:
         geom_expr = case(
             (FlowlineModel.nhdplus_comid == bindparam("trim_comid"), trimmed_geojson),
             else_=full_geojson,

--- a/src/nldi/db/navigation.py
+++ b/src/nldi/db/navigation.py
@@ -201,3 +201,40 @@ def navigation_query(mode: str, comid: int, distance: float) -> Select:
         msg = f"Invalid navigation mode: {mode}. Must be one of {', '.join(builders)}"
         raise ValueError(msg)
     return builder(comid, distance)
+
+
+def trim_nav_query(nav_mode: str, comid: int, trim_tolerance: float, measure: float) -> Select:
+    """Build a query that produces trimmed geometry for the starting flowline.
+
+    Uses ST_LineSubstring to clip the starting flowline's geometry based on
+    the feature's measure. Only the starting comid gets trimmed; other
+    flowlines get their full geometry via ST_AsGeoJSON.
+
+    For downstream modes (DM, DD): clip from measure to end of line.
+    For upstream modes (UM, UT): clip from start of line to measure.
+    """
+    from sqlalchemy import case, func, text
+
+    from .models import FlowlineModel
+
+    # Scale measure to a 0-1 fraction along the line
+    scaled_measure = 1 - ((measure - FlowlineModel.fmeasure) / (FlowlineModel.tmeasure - FlowlineModel.fmeasure))
+
+    if nav_mode.upper() in ("DM", "DD"):
+        trimmed_geojson = func.ST_AsGeoJSON(func.ST_LineSubstring(FlowlineModel.shape, scaled_measure, 1), 9, 0)
+    else:
+        trimmed_geojson = func.ST_AsGeoJSON(func.ST_LineSubstring(FlowlineModel.shape, 0, scaled_measure), 9, 0)
+
+    full_geojson = func.ST_AsGeoJSON(FlowlineModel.shape, 9, 0)
+
+    if 100 - measure >= trim_tolerance:
+        geom_expr = case(
+            (FlowlineModel.nhdplus_comid == bindparam("trim_comid"), trimmed_geojson),
+            else_=full_geojson,
+        )
+    else:
+        geom_expr = full_geojson
+
+    return select(FlowlineModel.nhdplus_comid.label("comid"), geom_expr.label("trimmed_geojson")).params(
+        trim_comid=comid
+    )

--- a/src/nldi/db/repos.py
+++ b/src/nldi/db/repos.py
@@ -90,6 +90,20 @@ class FlowlineRepository(SQLAlchemyAsyncRepository[FlowlineModel]):
         stmt = sqlalchemy.select(FlowlineModel).join(subq, FlowlineModel.nhdplus_comid == subq.c.comid)
         return list(await self.list(statement=stmt))
 
+    async def from_trimmed_nav_query(
+        self, nav_query: sqlalchemy.sql.Select, trim_query: sqlalchemy.sql.Select
+    ) -> list:  # list of (FlowlineModel, geojson_str) tuples
+        """Execute navigation + trim queries, return flowlines with trimmed geometry."""
+        nav_subq = nav_query.subquery()
+        trim_subq = trim_query.subquery()
+        stmt = (
+            sqlalchemy.select(FlowlineModel, trim_subq.c.trimmed_geojson)
+            .join(nav_subq, FlowlineModel.nhdplus_comid == nav_subq.c.comid)
+            .join(trim_subq, FlowlineModel.nhdplus_comid == trim_subq.c.comid)
+        )
+        result = await self.session.execute(stmt)
+        return list(result)
+
 
 class CatchmentRepository(SQLAlchemyAsyncRepository[CatchmentModel]):
     """Repository for catchment lookups."""


### PR DESCRIPTION
## What

`trimStart` and `trimTolerance` parameters on flowline navigation. Clips the starting flowline geometry using ST_LineSubstring based on the feature's measure.

## Plan

1. Add `trim_nav_query()` to navigation.py
2. Add `FlowlineRepository.from_trimmed_nav_query()`
3. Handler: accept trimStart/trimTolerance params, get measure, apply trim
4. Unit + integration tests