### PR TITLE
Health check no-cache + middleware respects existing headers

### DIFF
--- a/src/nldi/controllers/root.py
+++ b/src/nldi/controllers/root.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2024-present USGS
 """Root controller — landing page and health check."""
 
-from litestar import Controller, get, head
+from litestar import Controller, Response, get, head
 from litestar.response import Redirect
 
 from ..config import get_prefix
@@ -40,9 +40,10 @@ class RootController(Controller):
         }
 
     @get("/about/health", include_in_schema=False)
-    async def health_check(self) -> dict:
+    async def health_check(self) -> Response:
         """Health check for server and dependent services."""
-        return await health_status()
+        data = await health_status()
+        return Response(content=data, headers={"cache-control": "no-cache, no-store, max-age=0"})
 
     @get("/swagger-ui/index.html", include_in_schema=False)
     async def swagger_ui_redirect(self) -> Redirect:

--- a/src/nldi/middleware.py
+++ b/src/nldi/middleware.py
@@ -37,7 +37,9 @@ def headers_middleware_factory(app: ASGIApp) -> ASGIApp:
 
         async def send_with_headers(message):
             if message["type"] == "http.response.start":
-                message["headers"] = list(message.get("headers", [])) + STANDARD_HEADERS
+                existing_keys = {k for k, _v in message.get("headers", [])}
+                extra = [h for h in STANDARD_HEADERS if h[0] not in existing_keys]
+                message["headers"] = list(message.get("headers", [])) + extra
             await send(message)
 
         await app(scope, receive, send_with_headers)

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -28,6 +28,7 @@ def test_health_check():
         assert "db" in body
         assert "pygeoapi" in body
         assert body["server"]["status"] == "online"
+        assert "no-cache" in r.headers.get("cache-control", "")
 
 import pytest
 


### PR DESCRIPTION
Health endpoint should not be cached. Middleware now skips headers already set by the handler.