### PR TITLE
4.1: pygeoapi client with proper timeout handling

### DIFF
--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -59,3 +59,7 @@ After Phase 3 is complete, do a fit/finish pass on OpenAPI docs:
 - Document valid `nav_mode` values (UM, UT, DM, DD) with examples
 - Add response schema descriptions for FeatureCollection endpoints
 - Add meaningful operation summaries where auto-generated ones are insufficient
+
+## pygeoapi test URL
+
+Integration and system tests should use `https://nhgf.dev-wma.chs.usgs.gov/api/nldi/pygeoapi/` as `NLDI_PYGEOAPI_URL`. This is the dev instance — do not use production pygeoapi for testing.

--- a/src/nldi/asgi.py
+++ b/src/nldi/asgi.py
@@ -21,8 +21,9 @@ from .controllers.linked_data import (
     provide_source_repo,
 )
 from .controllers.root import RootController
-from .errors import problem_details_handler, unhandled_exception_handler
+from .errors import gateway_timeout_handler, problem_details_handler, unhandled_exception_handler
 from .middleware import headers_middleware_factory
+from .pygeoapi import PyGeoAPITimeoutError
 
 
 def _db_plugin() -> list:
@@ -64,6 +65,7 @@ def create_app(dependencies: dict | None = None) -> Litestar:
         logging_config=LoggingConfig(root={"level": get_log_level(), "handlers": ["queue_listener"]}),
         exception_handlers={  # ty: ignore[invalid-argument-type]
             HTTPException: problem_details_handler,
+            PyGeoAPITimeoutError: gateway_timeout_handler,
             Exception: unhandled_exception_handler,
         },
         middleware=[headers_middleware_factory],

--- a/src/nldi/errors.py
+++ b/src/nldi/errors.py
@@ -11,6 +11,7 @@ from litestar import Request, Response
 from litestar.exceptions import HTTPException
 
 from .media import MediaType
+from .pygeoapi import PyGeoAPITimeoutError
 
 logger = logging.getLogger(__name__)
 
@@ -44,3 +45,17 @@ def unhandled_exception_handler(_request: Request[Any, Any, Any], exc: Exception
         "instance": f"urn:error:{ref}",
     }
     return Response(content=body, status_code=500, media_type=MediaType.PROBLEM_JSON)
+
+
+def gateway_timeout_handler(_request: Request[Any, Any, Any], exc: PyGeoAPITimeoutError) -> Response[dict[str, Any]]:
+    """Return a 504 Gateway Timeout for pygeoapi timeouts."""
+    ref = uuid.uuid4().hex[:8]
+    logger.warning("pygeoapi timeout [%s]: %s", ref, exc)
+    body: dict[str, Any] = {
+        "type": "about:blank",
+        "title": "Gateway Timeout",
+        "status": 504,
+        "detail": "Upstream service timed out.",
+        "instance": f"urn:error:{ref}",
+    }
+    return Response(content=body, status_code=504, media_type=MediaType.PROBLEM_JSON)

--- a/src/nldi/pygeoapi.py
+++ b/src/nldi/pygeoapi.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2024-present USGS
+"""Client for pygeoapi external service calls.
+
+Handles timeouts and connection errors with distinct exceptions
+so the API can return 504 Gateway Timeout vs 500 Internal Server Error.
+"""
+
+import json
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 20  # seconds
+
+
+class PyGeoAPIError(Exception):
+    """Error communicating with pygeoapi service."""
+
+
+class PyGeoAPITimeoutError(PyGeoAPIError):
+    """Timeout communicating with pygeoapi service."""
+
+
+class PyGeoAPIClient:
+    """Async HTTP client for pygeoapi service."""
+
+    def __init__(self, base_url: str, timeout: int = DEFAULT_TIMEOUT):
+        """Initialize with pygeoapi base URL and default timeout."""
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    async def post(self, path: str, data: dict, timeout: int | None = None) -> dict:
+        """POST to a pygeoapi endpoint. Returns parsed JSON response."""
+        url = f"{self.base_url}/{path}"
+        _timeout = timeout or self.timeout
+        logger.info("POST (timeout=%s) to: %s", _timeout, url)
+
+        try:
+            async with httpx.AsyncClient(verify=False) as client:  # noqa: S501
+                r = await client.post(url, content=json.dumps(data), timeout=_timeout)
+                r.raise_for_status()
+                return r.json()
+        except httpx.TimeoutException as e:
+            raise PyGeoAPITimeoutError(f"Timeout calling {url}: {e}") from e
+        except httpx.ConnectError as e:
+            raise PyGeoAPIError(f"Cannot connect to {url}: {e}") from e
+        except httpx.HTTPStatusError as e:
+            raise PyGeoAPIError(f"HTTP error from {url}: {e}") from e
+        except json.JSONDecodeError as e:
+            raise PyGeoAPIError(f"Invalid JSON from {url}: {e}") from e

--- a/tests/unit/test_pygeoapi_client.py
+++ b/tests/unit/test_pygeoapi_client.py
@@ -1,0 +1,51 @@
+"""Unit tests for pygeoapi client."""
+
+import pytest
+
+
+def test_client_imports():
+    from nldi.pygeoapi import PyGeoAPIClient, PyGeoAPIError, PyGeoAPITimeoutError
+
+    assert PyGeoAPIClient is not None
+
+
+async def test_post_success(monkeypatch):
+    from nldi.pygeoapi import PyGeoAPIClient
+
+    async def mock_post(self, url, **kwargs):
+        class MockResponse:
+            status_code = 200
+            def json(self): return {"result": "ok"}
+            def raise_for_status(self): pass
+        return MockResponse()
+
+    monkeypatch.setattr("httpx.AsyncClient.post", mock_post)
+    client = PyGeoAPIClient("https://fake.example.com/pygeoapi")
+    result = await client.post("processes/test/execution", {"input": "data"})
+    assert result == {"result": "ok"}
+
+
+async def test_post_timeout_raises(monkeypatch):
+    import httpx
+    from nldi.pygeoapi import PyGeoAPIClient, PyGeoAPITimeoutError
+
+    async def mock_post(self, url, **kwargs):
+        raise httpx.TimeoutException("timed out")
+
+    monkeypatch.setattr("httpx.AsyncClient.post", mock_post)
+    client = PyGeoAPIClient("https://fake.example.com/pygeoapi")
+    with pytest.raises(PyGeoAPITimeoutError):
+        await client.post("processes/test/execution", {})
+
+
+async def test_post_connect_error_raises(monkeypatch):
+    import httpx
+    from nldi.pygeoapi import PyGeoAPIClient, PyGeoAPIError
+
+    async def mock_post(self, url, **kwargs):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr("httpx.AsyncClient.post", mock_post)
+    client = PyGeoAPIClient("https://fake.example.com/pygeoapi")
+    with pytest.raises(PyGeoAPIError, match="connection"):
+        await client.post("processes/test/execution", {})


### PR DESCRIPTION
## What

Shared httpx client for pygeoapi calls. Fixes issue #153 — catches timeouts and connection errors, raises distinct exceptions for 504 vs 500.

## Plan

1. `src/nldi/pygeoapi.py` — async POST client with timeout/connect error handling
2. Custom exceptions: `PyGeoAPITimeoutError`, `PyGeoAPIError`
3. Register exception handler for 504 Gateway Timeout
4. Config: `NLDI_PYGEOAPI_URL` env var (already introduced in health check)
5. Unit tests with mocked httpx