### PR TITLE
4.2: Hydrolocation endpoint

### DIFF
--- a/src/nldi/asgi.py
+++ b/src/nldi/asgi.py
@@ -18,6 +18,7 @@ from .controllers.linked_data import (
     provide_catchment_repo,
     provide_feature_repo,
     provide_flowline_repo,
+    provide_pygeoapi_client,
     provide_source_repo,
 )
 from .controllers.root import RootController
@@ -54,6 +55,7 @@ def create_app(dependencies: dict | None = None) -> Litestar:
         "feature_repo": Provide(provide_feature_repo),
         "flowline_repo": Provide(provide_flowline_repo),
         "catchment_repo": Provide(provide_catchment_repo),
+        "pygeoapi_client": Provide(provide_pygeoapi_client),
     }
     if dependencies:
         deps.update(dependencies)

--- a/src/nldi/controllers/linked_data.py
+++ b/src/nldi/controllers/linked_data.py
@@ -13,9 +13,11 @@ from ..config import get_base_url
 from ..db.navigation import NAV_DIST_DEFAULTS, NavigationModes, navigation_query, trim_nav_query
 from ..db.repos import CatchmentRepository, CrawlerSourceRepository, FeatureRepository, FlowlineRepository
 from ..dto import DataSource
-from ..geojson import Feature, FeatureCollection, parse_geometry
+from ..geojson import Feature, FeatureCollection, Point, parse_geometry
 from ..media import MediaType
 from ..negotiate import check_format
+from ..pygeoapi import PyGeoAPIClient
+from ..util import parse_wkt_point
 
 # Common parameter annotations for OpenAPI documentation
 SourceName = Annotated[str, Parameter(description="Data source identifier (e.g. 'wqp', 'nwissite', 'comid')")]
@@ -61,6 +63,14 @@ async def provide_flowline_repo(db_session: AsyncSession) -> FlowlineRepository:
 async def provide_catchment_repo(db_session: AsyncSession) -> CatchmentRepository:
     """Provide CatchmentRepository via DI."""
     return CatchmentRepository(session=db_session)
+
+
+def provide_pygeoapi_client() -> PyGeoAPIClient:
+    """Provide PyGeoAPIClient via DI."""
+    import os
+
+    url = os.getenv("NLDI_PYGEOAPI_URL", "")
+    return PyGeoAPIClient(url)
 
 
 async def _resolve_comid(source_name, identifier, source_repo, feature_repo, flowline_repo) -> int:
@@ -162,13 +172,88 @@ class LinkedDataController(Controller):
         return result
 
     @get("/hydrolocation")
-    async def get_hydrolocation(self, coords: CoordsParam = "") -> None:
+    async def get_hydrolocation(
+        self,
+        catchment_repo: Annotated[CatchmentRepository, Dependency(skip_validation=True)],
+        flowline_repo: Annotated[FlowlineRepository, Dependency(skip_validation=True)],
+        pygeoapi_client: Annotated[PyGeoAPIClient, Dependency(skip_validation=True)],
+        coords: CoordsParam = "",
+    ) -> Response:
         """Return hydrologic location nearest to coordinates.
 
-        Accepts a WKT point geometry and returns the nearest hydrologic location.
-        Not yet implemented.
+        Accepts a WKT point geometry and returns the nearest hydrologic location
+        on the NHD flowline network, plus the original provided point.
         """
-        _not_implemented()
+        if not coords:
+            raise ClientException(detail="coords parameter is required.")
+
+        try:
+            lon, lat = parse_wkt_point(coords)
+        except ValueError as e:
+            raise ClientException(detail=str(e)) from e
+
+        base_url = get_base_url()
+
+        # Call pygeoapi flowtrace
+        payload = {
+            "inputs": [
+                {"id": "lon", "type": "text/plain", "value": str(lon)},
+                {"id": "lat", "type": "text/plain", "value": str(lat)},
+                {"id": "direction", "type": "text/plain", "value": "none"},
+            ]
+        }
+        response = await pygeoapi_client.post("processes/nldi-flowtrace/execution", payload)
+        snap_lon, snap_lat = response["features"][0]["properties"]["intersection_point"]
+        snap_wkt = f"POINT({snap_lon} {snap_lat})"
+
+        # Find catchment at snapped point
+        catchment = await catchment_repo.get_by_point(snap_wkt)
+        if not catchment:
+            raise NotFoundException(detail=f"No catchment found at {coords}")
+        comid = catchment.featureid
+
+        # Compute measure and reachcode
+        measure, reachcode = await flowline_repo.get_measure_and_reachcode(comid, snap_wkt)
+
+        nav_url = f"{base_url}/linked-data/comid/{comid}/navigation"
+
+        indexed_feature = Feature(
+            geometry=Point(coordinates=(snap_lon, snap_lat)),
+            properties={
+                "identifier": "",
+                "navigation": nav_url,
+                "measure": measure,
+                "reachcode": reachcode,
+                "name": "",
+                "source": "indexed",
+                "sourceName": "Automatically indexed by the NLDI",
+                "comid": comid,
+                "type": "hydrolocation",
+                "uri": "",
+            },
+        )
+
+        provided_feature = Feature(
+            geometry=Point(coordinates=(lon, lat)),
+            properties={
+                "identifier": "",
+                "navigation": "",
+                "measure": "",
+                "reachcode": "",
+                "name": "",
+                "source": "provided",
+                "sourceName": "Provided via API call",
+                "comid": "",
+                "type": "point",
+                "uri": "",
+            },
+        )
+
+        return Response(
+            content=FeatureCollection(features=[indexed_feature, provided_feature]),
+            status_code=200,
+            media_type=MediaType.GEOJSON,
+        )
 
     @get("/comid/position")
     async def flowline_by_position(

--- a/src/nldi/db/repos.py
+++ b/src/nldi/db/repos.py
@@ -104,6 +104,25 @@ class FlowlineRepository(SQLAlchemyAsyncRepository[FlowlineModel]):
         result = await self.session.execute(stmt)
         return list(result)
 
+    async def get_measure_and_reachcode(self, comid: int, wkt_point: str) -> tuple[float | None, str | None]:
+        """Compute measure and reachcode for a point on a flowline."""
+        measure_expr = (
+            FlowlineModel.fmeasure
+            + (
+                1
+                - sqlalchemy.func.ST_LineLocatePoint(
+                    FlowlineModel.shape, sqlalchemy.func.ST_GeomFromText(wkt_point, 4269)
+                )
+            )
+            * (FlowlineModel.tmeasure - FlowlineModel.fmeasure)
+        ).label("measure")
+        stmt = sqlalchemy.select(measure_expr, FlowlineModel.reachcode).where(FlowlineModel.nhdplus_comid == comid)
+        result = await self.session.execute(stmt)
+        row = result.fetchone()
+        if not row:
+            return None, None
+        return float(row[0]) if row[0] is not None else None, row[1]
+
 
 class CatchmentRepository(SQLAlchemyAsyncRepository[CatchmentModel]):
     """Repository for catchment lookups."""

--- a/src/nldi/util.py
+++ b/src/nldi/util.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2024-present USGS
+"""Small utilities — no heavy dependencies."""
+
+import re
+
+_WKT_POINT_RE = re.compile(r"POINT\s*\(\s*([+-]?\d+\.?\d*)\s+([+-]?\d+\.?\d*)\s*\)", re.IGNORECASE)
+
+
+def parse_wkt_point(wkt: str) -> tuple[float, float]:
+    """Parse a WKT POINT string to (lon, lat). No shapely needed."""
+    m = _WKT_POINT_RE.match(wkt.strip())
+    if not m:
+        raise ValueError(f"Invalid WKT point: {wkt}")
+    return float(m.group(1)), float(m.group(2))

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -128,6 +128,10 @@ class FakeFlowlineRepository:
         """Fake: return all flowlines (ignores nav query)."""
         return self._flowlines
 
+    async def get_measure_and_reachcode(self, comid: int, wkt_point: str) -> tuple:
+        """Fake: return dummy measure and reachcode."""
+        return 50.0, "00000000000000"
+
 
 class FakeCatchmentModel:
     """Minimal stand-in for CatchmentModel."""

--- a/tests/unit/test_hydrolocation.py
+++ b/tests/unit/test_hydrolocation.py
@@ -1,0 +1,79 @@
+"""Unit tests for hydrolocation endpoint."""
+
+import os
+
+from litestar.di import Provide
+from litestar.testing import TestClient
+
+from nldi.asgi import create_app
+
+
+class FakePyGeoAPIClient:
+    """Fake pygeoapi client that returns a canned flowtrace response."""
+
+    async def post(self, path, data, timeout=None):
+        return {
+            "features": [{
+                "properties": {
+                    "intersection_point": [-89.472, 43.098]
+                }
+            }]
+        }
+
+
+class FakePyGeoAPIClientTimeout:
+    """Fake pygeoapi client that raises timeout."""
+
+    async def post(self, path, data, timeout=None):
+        from nldi.pygeoapi import PyGeoAPITimeoutError
+        raise PyGeoAPITimeoutError("timed out")
+
+
+def _app_with_fakes(catchment_repo, flowline_repo, pygeoapi_client):
+    os.environ.setdefault("NLDI_BASE_URL", "https://test.example.com/nldi")
+    return create_app(dependencies={
+        "catchment_repo": Provide(lambda: catchment_repo, sync_to_thread=False),
+        "flowline_repo": Provide(lambda: flowline_repo, sync_to_thread=False),
+        "pygeoapi_client": Provide(lambda: pygeoapi_client, sync_to_thread=False),
+    })
+
+
+class TestHydrolocation:
+    def test_missing_coords_returns_400(self, fake_catchment_repo, fake_flowline_repo):
+        app = _app_with_fakes(fake_catchment_repo([]), fake_flowline_repo([]), FakePyGeoAPIClient())
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/hydrolocation")
+            assert r.status_code == 400
+
+    def test_invalid_coords_returns_400(self, fake_catchment_repo, fake_flowline_repo):
+        app = _app_with_fakes(fake_catchment_repo([]), fake_flowline_repo([]), FakePyGeoAPIClient())
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/hydrolocation?coords=NOTAPOINT")
+            assert r.status_code == 400
+
+    def test_valid_coords_returns_two_features(
+        self, fake_catchment_repo, make_catchment, fake_flowline_repo, make_flowline
+    ):
+        app = _app_with_fakes(
+            fake_catchment_repo([make_catchment(13294314)]),
+            fake_flowline_repo([make_flowline(13294314)]),
+            FakePyGeoAPIClient(),
+        )
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/hydrolocation?coords=POINT(-89.509 43.087)")
+            assert r.status_code == 200
+            body = r.json()
+            assert body["type"] == "FeatureCollection"
+            assert len(body["features"]) == 2
+            assert body["features"][0]["properties"]["source"] == "indexed"
+            assert body["features"][1]["properties"]["source"] == "provided"
+
+    def test_pygeoapi_timeout_returns_504(self, fake_catchment_repo, fake_flowline_repo):
+        app = _app_with_fakes(
+            fake_catchment_repo([]),
+            fake_flowline_repo([]),
+            FakePyGeoAPIClientTimeout(),
+        )
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/hydrolocation?coords=POINT(-89.509 43.087)")
+            assert r.status_code == 504

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -33,7 +33,6 @@ def test_health_check():
 import pytest
 
 STUB_PATHS = [
-    "/api/nldi/linked-data/hydrolocation?coords=POINT(-89 43)",
     "/api/nldi/linked-data/wqp/USGS-01/basin",
 ]
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,0 +1,21 @@
+"""Unit tests for utilities."""
+
+import pytest
+
+from nldi.util import parse_wkt_point
+
+
+def test_parse_valid_point():
+    lon, lat = parse_wkt_point("POINT(-89.509 43.087)")
+    assert lon == -89.509
+    assert lat == 43.087
+
+
+def test_parse_point_with_spaces():
+    lon, lat = parse_wkt_point("POINT( -89.509  43.087 )")
+    assert lon == -89.509
+
+
+def test_parse_invalid_raises():
+    with pytest.raises(ValueError, match="Invalid WKT"):
+        parse_wkt_point("NOT A POINT")


### PR DESCRIPTION
## What

`GET /linked-data/hydrolocation?coords=POINT(lon lat)` — find nearest hydrologic location. See [spec](docs/specs/pr-4.2-hydrolocation.md).

## Plan

1. `parse_wkt_point()` — regex, no shapely
2. PyGeoAPIClient flowtrace call
3. FlowlineRepository: measure + reachcode for a comid
4. Handler: coords → flowtrace → catchment → measure → two Features
5. Unit tests with mocked pygeoapi