### PR TITLE
4.4b: Wire split catchment into basin handler

### DIFF
--- a/src/nldi/controllers/linked_data.py
+++ b/src/nldi/controllers/linked_data.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2024-present USGS
 """Linked data controller — all NLDI data endpoints."""
 
+import json
 from typing import Annotated
 
 from litestar import Controller, Response, get, head
@@ -362,25 +363,96 @@ class LinkedDataController(Controller):
         feature_repo: Annotated[FeatureRepository, Dependency(skip_validation=True)],
         flowline_repo: Annotated[FlowlineRepository, Dependency(skip_validation=True)],
         catchment_repo: Annotated[CatchmentRepository, Dependency(skip_validation=True)],
+        pygeoapi_client: Annotated[PyGeoAPIClient, Dependency(skip_validation=True)],
         simplified: Annotated[bool, Parameter(description="Simplify basin geometry")] = True,
+        split_catchment: Annotated[
+            bool, Parameter(query="splitCatchment", description="Split catchment at feature point")
+        ] = False,
     ) -> Response:
         """Compute upstream basin polygon.
 
         Returns the aggregated drainage basin for the specified feature
         as a GeoJSON FeatureCollection with a single Polygon/MultiPolygon.
+        Optionally splits the local catchment at the feature's position.
         """
-        comid = await _resolve_comid(source_name, identifier, source_repo, feature_repo, flowline_repo)
-        nav_q = basin_query(comid)
-        geojson_str = await catchment_repo.get_drainage_basin(nav_q, simplified=simplified)
-        if not geojson_str:
-            raise NotFoundException(detail=f"No basin found for {source_name}/{identifier}")
+        if split_catchment and source_name.lower() == "comid":
+            raise ClientException(detail="Cannot use splitCatchment with comid source.")
 
-        feature = Feature(
-            geometry=parse_geometry(geojson_str),
-            properties={},
-            id=0,
-        )
+        comid = await _resolve_comid(source_name, identifier, source_repo, feature_repo, flowline_repo)
+
+        if split_catchment and source_name.lower() != "comid":
+            # Find a point on the flowline using three fallback strategies
+            point = await self._find_point_on_flowline(
+                identifier, source_name, flowline_repo, feature_repo, pygeoapi_client
+            )
+            if not point:
+                raise NotFoundException(detail="Unable to retrieve point on flowline for catchment splitting.")
+
+            lon, lat = point
+            result = await pygeoapi_client.splitcatchment(lon, lat)
+            if not result or "geometry" not in result:
+                raise NotFoundException(detail="Split catchment service returned no result.")
+
+            feature = Feature(
+                geometry=parse_geometry(json.dumps(result["geometry"])),
+                properties={},
+                id=0,
+            )
+        else:
+            nav_q = basin_query(comid)
+            geojson_str = await catchment_repo.get_drainage_basin(nav_q, simplified=simplified)
+            if not geojson_str:
+                raise NotFoundException(detail=f"No basin found for {source_name}/{identifier}")
+
+            feature = Feature(
+                geometry=parse_geometry(geojson_str),
+                properties={},
+                id=0,
+            )
+
         return Response(content=FeatureCollection(features=[feature]), status_code=200, media_type=MediaType.GEOJSON)
+
+    SPLIT_CATCHMENT_THRESHOLD = 200  # meters
+
+    async def _find_point_on_flowline(
+        self, identifier, source_name, flowline_repo, feature_repo, pygeoapi_client
+    ) -> tuple[float, float] | None:
+        """Find a point on the flowline for split catchment. Three fallback strategies."""
+        # Plan A: interpolate from measure
+        point = await flowline_repo.feat_get_point_along_flowline(identifier, source_name)
+        if point:
+            return point
+
+        # Plan B: nearest point if within threshold
+        try:
+            distance = await flowline_repo.feat_get_distance_from_flowline(identifier, source_name)
+            if distance is not None and distance <= self.SPLIT_CATCHMENT_THRESHOLD:
+                point = await flowline_repo.feat_get_nearest_point_on_flowline(identifier, source_name)
+                if point:
+                    return point
+        except (LookupError, TypeError, ValueError):
+            pass
+
+        # Plan C: pygeoapi flowtrace
+        try:
+            feat = await feature_repo.feature_lookup(source_name, identifier)
+            if feat and feat.location:
+                geom = json.loads(str(feat.location))
+                lon, lat = geom["coordinates"]
+                payload = {
+                    "inputs": [
+                        {"id": "lon", "type": "text/plain", "value": str(lon)},
+                        {"id": "lat", "type": "text/plain", "value": str(lat)},
+                        {"id": "direction", "type": "text/plain", "value": "none"},
+                    ]
+                }
+                response = await pygeoapi_client.post("processes/nldi-flowtrace/execution", payload)
+                snap_lon, snap_lat = response["features"][0]["properties"]["intersection_point"]
+                return (snap_lon, snap_lat)
+        except (LookupError, TypeError, ValueError, KeyError):
+            pass
+
+        return None
 
     @get("/{source_name:str}/{identifier:str}/navigation", tags=["by_sourceid"])
     async def get_navigation_modes(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,11 +14,11 @@ class FakeSource:
 class FakeFeatureModel:
     """Minimal stand-in for FeatureSourceModel."""
 
-    def __init__(self, identifier: str, source_suffix: str, source_name: str, name: str, uri: str):
+    def __init__(self, identifier: str, source_suffix: str, source_name: str, name: str, uri: str, comid: int | None = None):
         self.identifier = identifier
         self.name = name
         self.uri = uri
-        self.comid = None
+        self.comid = comid
         self.reachcode = None
         self.measure = None
         self.location = None
@@ -131,6 +131,20 @@ class FakeFlowlineRepository:
     async def get_measure_and_reachcode(self, comid: int, wkt_point: str) -> tuple:
         """Fake: return dummy measure and reachcode."""
         return 50.0, "00000000000000"
+
+    async def feat_get_point_along_flowline(self, feature_id: str, feature_source: str):
+        """Fake: return a point if flowlines exist, else None."""
+        if self._flowlines:
+            return (-89.47, 43.09)
+        return None
+
+    async def feat_get_distance_from_flowline(self, feature_id: str, feature_source: str):
+        """Fake: return None."""
+        return None
+
+    async def feat_get_nearest_point_on_flowline(self, feature_id: str, feature_source: str):
+        """Fake: return None."""
+        return None
 
 
 class FakeCatchmentModel:

--- a/tests/unit/test_basin_split.py
+++ b/tests/unit/test_basin_split.py
@@ -1,0 +1,87 @@
+"""Unit tests for basin split catchment."""
+
+import os
+
+from litestar.di import Provide
+from litestar.testing import TestClient
+
+from nldi.asgi import create_app
+
+
+class FakePyGeoAPISplitClient:
+    """Fake pygeoapi client that returns a split catchment polygon."""
+
+    async def post(self, path, data, timeout=None):
+        if "splitcatchment" in path:
+            return {
+                "features": [
+                    {"id": "mergedCatchment", "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]]}}
+                ]
+            }
+        # flowtrace
+        return {"features": [{"properties": {"intersection_point": [-89.47, 43.09]}}]}
+
+    async def splitcatchment(self, lon, lat):
+        return {"geometry": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]]}}
+
+
+def _app_with_fakes(source_repo, feature_repo, flowline_repo, catchment_repo, pygeoapi_client):
+    os.environ.setdefault("NLDI_BASE_URL", "https://test.example.com/nldi")
+    return create_app(dependencies={
+        "source_repo": Provide(lambda: source_repo, sync_to_thread=False),
+        "feature_repo": Provide(lambda: feature_repo, sync_to_thread=False),
+        "flowline_repo": Provide(lambda: flowline_repo, sync_to_thread=False),
+        "catchment_repo": Provide(lambda: catchment_repo, sync_to_thread=False),
+        "pygeoapi_client": Provide(lambda: pygeoapi_client, sync_to_thread=False),
+    })
+
+
+class TestBasinSplitCatchment:
+    def test_split_catchment_with_comid_returns_400(
+        self, fake_source_repo, fake_feature_repo, fake_flowline_repo, fake_catchment_repo
+    ):
+        app = _app_with_fakes(
+            fake_source_repo([]),
+            fake_feature_repo([]),
+            fake_flowline_repo([]),
+            fake_catchment_repo([]),
+            FakePyGeoAPISplitClient(),
+        )
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/comid/123/basin?splitCatchment=true")
+            assert r.status_code == 400
+
+    def test_split_catchment_returns_polygon(
+        self, fake_source_repo, make_source, fake_feature_repo, make_feature, fake_flowline_repo, make_flowline, fake_catchment_repo, make_catchment
+    ):
+        """Split catchment should return a polygon when pygeoapi succeeds."""
+        app = _app_with_fakes(
+            fake_source_repo([make_source("wqp", "WQP")]),
+            fake_feature_repo([make_feature("USGS-01", "wqp", "WQP", "Site", "https://example.com", comid=123)]),
+            fake_flowline_repo([make_flowline(123)]),
+            fake_catchment_repo([make_catchment(123)]),
+            FakePyGeoAPISplitClient(),
+        )
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/wqp/USGS-01/basin?splitCatchment=true")
+            assert r.status_code == 200
+            body = r.json()
+            assert body["type"] == "FeatureCollection"
+            assert body["features"][0]["geometry"]["type"] == "Polygon"
+
+    def test_simple_basin_still_works(
+        self, fake_source_repo, fake_feature_repo, fake_flowline_repo, fake_catchment_repo, make_catchment
+    ):
+        """Without splitCatchment, should use the simple basin path."""
+        app = _app_with_fakes(
+            fake_source_repo([]),
+            fake_feature_repo([]),
+            fake_flowline_repo([]),
+            fake_catchment_repo([make_catchment(13293396)]),
+            FakePyGeoAPISplitClient(),
+        )
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/comid/13293396/basin")
+            assert r.status_code == 200
+            body = r.json()
+            assert body["features"][0]["geometry"]["type"] == "Polygon"


### PR DESCRIPTION
## What

Plan A → B → C fallback logic for split catchment in basin endpoint.

## Plan

1. Handler: when splitCatchment=true and source != comid, run fallback logic
2. Plan A: feat_get_point_along_flowline (measure-based)
3. Plan B: feat_get_distance_from_flowline + feat_get_nearest_point (threshold 200m)
4. Plan C: pygeoapi flowtrace → intersection point
5. Once point found: pygeoapi splitcatchment → return polygon
6. Unit tests for each fallback path