### PR TITLE
Remove advanced-alchemy: own the session lifecycle

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -75,7 +75,7 @@ tasks:
   dev:
     desc: Run app locally with decrypted secrets from ~/.secrets/nldi.env.gpg
     cmds:
-      - env $(gpg --quiet --decrypt ~/.secrets/nldi.env.gpg | xargs) uv run uvicorn nldi.asgi:app --reload
+      - env $(gpg --quiet --decrypt ~/.secrets/nldi.env.gpg | xargs) uv run uvicorn nldi.asgi:app --reload --timeout-graceful-shutdown 5 
 
   check:
     desc: Pre-commit gate — lint, format check, unit tests

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -20,7 +20,7 @@
 
 | Dependency | Role | Decision |
 | --- | --- | --- |
-| advanced-alchemy | ORM repository layer | Keep for now. Provides familiar repository pattern (`get`, `list`, `get_one_or_none`) for simple Phase 2 lookups. Repos are the formal boundary between data/object models (Amundsen's Maxim). Phase 3 complex queries (navigation CTEs) may bypass repos. Decision is reversible — repos are thin, controllers never import advanced-alchemy directly. |
+| advanced-alchemy | ORM repository layer | **Removed.** Replaced with a minimal `AsyncRepository` base class (~15 lines) and explicit session lifecycle management via `provide_db_session()`. Gives us full control over connection cleanup on client disconnect, eliminating zombie DB connections under load. |
 
 ## Evaluate
 

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -73,3 +73,19 @@ Integration and system tests should use `https://nhgf.dev-wma.chs.usgs.gov/api/n
 - `controllers/linked_data/__init__.py` — shared helpers, DI providers, re-exports
 
 Do as a cleanup PR after Phase 4.
+
+## Session lifecycle (PR #192)
+
+Advanced-alchemy was removed because it wrapped SQLAlchemy exceptions
+(hiding `TimeoutError` behind `RepositoryError`), owned the session
+lifecycle, and installed its own exception handler. Under load, client
+disconnects left DB connections checked out ("zombie connections").
+
+Replaced with:
+- `db/__init__.py`: `get_engine()` singleton with pool config +
+  `provide_db_session()` async generator with `try/except/finally`
+  guaranteeing rollback+close on error or client disconnect.
+- `db/repos.py`: `AsyncRepository` base class (~15 lines) providing
+  `list(statement)` and `get_one_or_none(*filters, statement=)`.
+- `statement_timeout=120s` on all Postgres connections as a server-side
+  safety net for runaway queries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 dependencies = [
   "litestar[standard]>=2.21.0,<3",
   "uvicorn>=0.34.0,<0.35",
-  "advanced-alchemy>=1.8.0,<2",
   "sqlalchemy[asyncio]>=2.0,<3",
   "asyncpg>=0.30.0,<1",
   "geoalchemy2>=0.16.0,<0.17",

--- a/src/nldi/asgi.py
+++ b/src/nldi/asgi.py
@@ -2,6 +2,9 @@
 # SPDX-FileCopyrightText: 2024-present USGS
 """ASGI application factory."""
 
+import asyncio
+import logging
+
 import sqlalchemy.exc
 from litestar import Litestar
 from litestar.di import Provide
@@ -34,6 +37,16 @@ from .errors import (
 from .middleware import headers_middleware_factory, timing_middleware_factory
 from .pygeoapi import PyGeoAPITimeoutError
 
+_logger = logging.getLogger(__name__)
+
+
+async def _log_pending_tasks() -> None:
+    """Log any tasks still running at shutdown."""
+    current = asyncio.current_task()
+    pending = [t for t in asyncio.all_tasks() if not t.done() and t is not current]
+    if pending:
+        _logger.warning("Shutdown: %d pending task(s)", len(pending))
+
 
 def create_app(dependencies: dict | None = None) -> Litestar:
     """Create and configure the Litestar ASGI application."""
@@ -60,12 +73,13 @@ def create_app(dependencies: dict | None = None) -> Litestar:
         exception_handlers={  # ty: ignore[invalid-argument-type]
             HTTPException: problem_details_handler,
             PyGeoAPITimeoutError: gateway_timeout_handler,
-            sqlalchemy.exc.OperationalError: db_unavailable_handler,
+            sqlalchemy.exc.DBAPIError: db_unavailable_handler,
             sqlalchemy.exc.TimeoutError: db_unavailable_handler,
             TimeoutError: db_unavailable_handler,
             Exception: unhandled_exception_handler,
         },
         middleware=[headers_middleware_factory],
+        on_shutdown=[_log_pending_tasks],
         openapi_config=OpenAPIConfig(
             title=__title__,
             version=__version__,

--- a/src/nldi/asgi.py
+++ b/src/nldi/asgi.py
@@ -3,9 +3,6 @@
 """ASGI application factory."""
 
 import sqlalchemy.exc
-from advanced_alchemy.exceptions import RepositoryError
-from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
-from advanced_alchemy.extensions.litestar.plugins.init.config.engine import EngineConfig
 from litestar import Litestar
 from litestar.di import Provide
 from litestar.exceptions import HTTPException
@@ -15,7 +12,7 @@ from litestar.openapi.plugins import SwaggerRenderPlugin
 from litestar.router import Router
 
 from . import __description__, __title__, __version__
-from .config import get_database_url, get_log_level, get_prefix
+from .config import get_log_level, get_prefix
 from .controllers.linked_data import (
     provide_catchment_repo,
     provide_feature_repo,
@@ -27,6 +24,7 @@ from .controllers.linked_data.basin import BasinController
 from .controllers.linked_data.lookups import LookupController
 from .controllers.linked_data.navigation import NavigationController
 from .controllers.root import RootController
+from .db import provide_db_session
 from .errors import (
     db_unavailable_handler,
     gateway_timeout_handler,
@@ -37,33 +35,10 @@ from .middleware import headers_middleware_factory, timing_middleware_factory
 from .pygeoapi import PyGeoAPITimeoutError
 
 
-def _db_plugin() -> list:
-    """Return SQLAlchemy plugin if DB env vars are set, else empty list."""
-    try:
-        url = get_database_url()
-    except RuntimeError:
-        return []
-    return [
-        SQLAlchemyPlugin(
-            config=SQLAlchemyAsyncConfig(
-                connection_string=url,
-                create_all=False,
-                set_default_exception_handler=False,
-                engine_config=EngineConfig(
-                    pool_pre_ping=True,
-                    pool_size=10,
-                    max_overflow=10,
-                    pool_timeout=60,
-                    connect_args={"server_settings": {"statement_timeout": "120000"}},
-                ),
-            )
-        )
-    ]
-
-
 def create_app(dependencies: dict | None = None) -> Litestar:
     """Create and configure the Litestar ASGI application."""
     deps = {
+        "db_session": Provide(provide_db_session),
         "source_repo": Provide(provide_source_repo),
         "feature_repo": Provide(provide_feature_repo),
         "flowline_repo": Provide(provide_flowline_repo),
@@ -80,13 +55,11 @@ def create_app(dependencies: dict | None = None) -> Litestar:
     return Litestar(
         route_handlers=[RootController, linked_data_router],
         path=get_prefix(),
-        plugins=_db_plugin(),
         dependencies=deps,
         logging_config=LoggingConfig(root={"level": get_log_level(), "handlers": ["queue_listener"]}),
         exception_handlers={  # ty: ignore[invalid-argument-type]
             HTTPException: problem_details_handler,
             PyGeoAPITimeoutError: gateway_timeout_handler,
-            RepositoryError: db_unavailable_handler,
             sqlalchemy.exc.OperationalError: db_unavailable_handler,
             sqlalchemy.exc.TimeoutError: db_unavailable_handler,
             TimeoutError: db_unavailable_handler,

--- a/src/nldi/asgi.py
+++ b/src/nldi/asgi.py
@@ -73,8 +73,7 @@ def create_app(dependencies: dict | None = None) -> Litestar:
         exception_handlers={  # ty: ignore[invalid-argument-type]
             HTTPException: problem_details_handler,
             PyGeoAPITimeoutError: gateway_timeout_handler,
-            sqlalchemy.exc.DBAPIError: db_unavailable_handler,
-            sqlalchemy.exc.TimeoutError: db_unavailable_handler,
+            sqlalchemy.exc.SQLAlchemyError: db_unavailable_handler,
             TimeoutError: db_unavailable_handler,
             Exception: unhandled_exception_handler,
         },

--- a/src/nldi/controllers/linked_data/lookups.py
+++ b/src/nldi/controllers/linked_data/lookups.py
@@ -8,7 +8,6 @@ import msgspec
 from litestar import Controller, Response, get, head
 from litestar.params import Dependency, Parameter
 
-from ...db.models import FlowlineModel
 from ...dto import DataSource
 from ...geojson import Feature, FeatureCollection, Point, parse_geometry
 from ...jsonld import to_jsonld_graph, to_jsonld_single
@@ -199,7 +198,7 @@ class LookupController(Controller):
 
             raise NotFoundException(detail=f"No catchment found at coords {coords}")
         comid = catchment.featureid
-        flowline = await flowline_repo.get_one_or_none(FlowlineModel.nhdplus_comid == comid)
+        flowline = await flowline_repo.get_by_comid(comid)
         if not flowline:
             from litestar.exceptions import NotFoundException
 
@@ -262,7 +261,7 @@ class LookupController(Controller):
                 from litestar.exceptions import ClientException
 
                 raise ClientException(detail=f"Not a valid comid: {identifier}") from e
-            flowline = await flowline_repo.get_one_or_none(FlowlineModel.nhdplus_comid == comid)
+            flowline = await flowline_repo.get_by_comid(comid)
             if not flowline:
                 from litestar.exceptions import NotFoundException
 

--- a/src/nldi/controllers/linked_data/lookups.py
+++ b/src/nldi/controllers/linked_data/lookups.py
@@ -8,6 +8,7 @@ import msgspec
 from litestar import Controller, Response, get, head
 from litestar.params import Dependency, Parameter
 
+from ...db.models import FlowlineModel
 from ...dto import DataSource
 from ...geojson import Feature, FeatureCollection, Point, parse_geometry
 from ...jsonld import to_jsonld_graph, to_jsonld_single
@@ -185,6 +186,12 @@ class LookupController(Controller):
             from litestar.exceptions import ClientException
 
             raise ClientException(detail="coords parameter is required.")
+        try:
+            parse_wkt_point(coords)
+        except ValueError as e:
+            from litestar.exceptions import ClientException
+
+            raise ClientException(detail=str(e))
         base_url = get_base_url()
         catchment = await catchment_repo.get_by_point(coords)
         if not catchment:
@@ -192,7 +199,7 @@ class LookupController(Controller):
 
             raise NotFoundException(detail=f"No catchment found at coords {coords}")
         comid = catchment.featureid
-        flowline = await flowline_repo.get_one_or_none(nhdplus_comid=comid)
+        flowline = await flowline_repo.get_one_or_none(FlowlineModel.nhdplus_comid == comid)
         if not flowline:
             from litestar.exceptions import NotFoundException
 
@@ -255,7 +262,7 @@ class LookupController(Controller):
                 from litestar.exceptions import ClientException
 
                 raise ClientException(detail=f"Not a valid comid: {identifier}") from e
-            flowline = await flowline_repo.get_one_or_none(nhdplus_comid=comid)
+            flowline = await flowline_repo.get_one_or_none(FlowlineModel.nhdplus_comid == comid)
             if not flowline:
                 from litestar.exceptions import NotFoundException
 

--- a/src/nldi/db/__init__.py
+++ b/src/nldi/db/__init__.py
@@ -1,3 +1,46 @@
 # SPDX-License-Identifier: CC0-1.0
 # SPDX-FileCopyrightText: 2024-present USGS
-"""NLDI database access layer."""
+"""NLDI database access layer.
+
+Engine singleton and async session provider. The session provider
+guarantees rollback+close on error or client disconnect, preventing
+zombie connections in the pool.
+"""
+
+from collections.abc import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
+
+from ..config import get_database_url
+
+_engine: AsyncEngine | None = None
+
+
+def get_engine() -> AsyncEngine:
+    """Return the shared async engine, creating it on first call."""
+    global _engine  # noqa: PLW0603
+    if _engine is None:
+        _engine = create_async_engine(
+            get_database_url(),
+            pool_pre_ping=True,
+            pool_size=10,
+            max_overflow=10,
+            pool_timeout=60,
+            connect_args={"server_settings": {"statement_timeout": "120000"}},
+        )
+    return _engine
+
+
+async def provide_db_session() -> AsyncGenerator[AsyncSession, None]:
+    """Provide an async session with guaranteed cleanup.
+
+    On success the session is committed. On any exception — including
+    ``asyncio.CancelledError`` from a client disconnect — the session
+    is rolled back. The connection is always returned to the pool.
+    """
+    async with AsyncSession(get_engine()) as session:
+        try:
+            yield session
+        except Exception:
+            await session.rollback()
+            raise

--- a/src/nldi/db/__init__.py
+++ b/src/nldi/db/__init__.py
@@ -24,9 +24,9 @@ def get_engine() -> AsyncEngine:
             get_database_url(),
             pool_pre_ping=True,
             pool_size=10,
-            max_overflow=10,
+            max_overflow=30,
             pool_timeout=60,
-            connect_args={"server_settings": {"statement_timeout": "120000"}},
+            connect_args={"server_settings": {"statement_timeout": "120s"}},
         )
     return _engine
 

--- a/src/nldi/db/__init__.py
+++ b/src/nldi/db/__init__.py
@@ -8,32 +8,29 @@ zombie connections in the pool.
 """
 
 from collections.abc import AsyncGenerator
+from functools import lru_cache
 
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 
 from ..config import get_database_url
 
-_engine: AsyncEngine | None = None
 
-
+@lru_cache(maxsize=1)
 def get_engine() -> AsyncEngine:
     """Return the shared async engine, creating it on first call."""
-    global _engine  # noqa: PLW0603
-    if _engine is None:
-        _engine = create_async_engine(
-            get_database_url(),
-            pool_pre_ping=True,
-            pool_size=10,
-            max_overflow=30,
-            pool_timeout=60,
-            connect_args={
-                "server_settings": {
-                    "statement_timeout": "120s",
-                    "idle_in_transaction_session_timeout": "30s",
-                }
-            },
-        )
-    return _engine
+    return create_async_engine(
+        get_database_url(),
+        pool_pre_ping=True,
+        pool_size=10,
+        max_overflow=30,
+        pool_timeout=60,
+        connect_args={
+            "server_settings": {
+                "statement_timeout": "120s",
+                "idle_in_transaction_session_timeout": "30s",
+            }
+        },
+    )
 
 
 async def provide_db_session() -> AsyncGenerator[AsyncSession, None]:

--- a/src/nldi/db/__init__.py
+++ b/src/nldi/db/__init__.py
@@ -26,7 +26,12 @@ def get_engine() -> AsyncEngine:
             pool_size=10,
             max_overflow=30,
             pool_timeout=60,
-            connect_args={"server_settings": {"statement_timeout": "120s"}},
+            connect_args={
+                "server_settings": {
+                    "statement_timeout": "120s",
+                    "idle_in_transaction_session_timeout": "30s",
+                }
+            },
         )
     return _engine
 

--- a/src/nldi/db/repos.py
+++ b/src/nldi/db/repos.py
@@ -22,9 +22,10 @@ class AsyncRepository:
         """Initialize with an async session."""
         self.session = session
 
-    async def list(self, statement: sqlalchemy.sql.Select) -> list:
+    async def list(self, statement: sqlalchemy.sql.Select | None = None) -> list:
         """Execute a SELECT and return all model instances."""
-        result = await self.session.execute(statement)
+        stmt = statement if statement is not None else sqlalchemy.select(self.model_type)
+        result = await self.session.execute(stmt)
         return list(result.scalars())
 
     async def get_one_or_none(self, *filters: sqlalchemy.ColumnElement, statement: sqlalchemy.sql.Select | None = None):

--- a/src/nldi/db/repos.py
+++ b/src/nldi/db/repos.py
@@ -98,6 +98,10 @@ class FlowlineRepository(AsyncRepository):
 
     model_type = FlowlineModel
 
+    async def get_by_comid(self, comid: int) -> FlowlineModel | None:
+        """Look up a flowline by comid."""
+        return await self.get_one_or_none(FlowlineModel.nhdplus_comid == comid)
+
     async def list_all(self, limit: int = 0, offset: int = 0) -> list[FlowlineModel]:
         """List flowlines with optional pagination."""
         stmt = sqlalchemy.select(FlowlineModel).order_by(FlowlineModel.nhdplus_comid).offset(offset)

--- a/src/nldi/db/repos.py
+++ b/src/nldi/db/repos.py
@@ -2,22 +2,44 @@
 # SPDX-FileCopyrightText: 2024-present USGS
 """Repositories for NLDI data access.
 
-Thin wrappers around advanced-alchemy's async repository.
+Thin wrappers around plain SQLAlchemy async sessions.
 These are the boundary between the data model and the rest of the application.
 """
 
 import geoalchemy2
 import sqlalchemy
-from advanced_alchemy.repository import SQLAlchemyAsyncRepository
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from .models import CatchmentModel, CrawlerSourceModel, FeatureSourceModel, FlowlineModel
 
 
-class CrawlerSourceRepository(SQLAlchemyAsyncRepository[CrawlerSourceModel]):
+class AsyncRepository:
+    """Minimal async repository base with list and get_one_or_none."""
+
+    model_type: type
+
+    def __init__(self, session: AsyncSession):
+        """Initialize with an async session."""
+        self.session = session
+
+    async def list(self, statement: sqlalchemy.sql.Select) -> list:
+        """Execute a SELECT and return all model instances."""
+        result = await self.session.execute(statement)
+        return list(result.scalars())
+
+    async def get_one_or_none(self, *filters: sqlalchemy.ColumnElement, statement: sqlalchemy.sql.Select | None = None):
+        """Execute a filtered SELECT and return one result or None."""
+        stmt = statement if statement is not None else sqlalchemy.select(self.model_type)
+        for f in filters:
+            stmt = stmt.where(f)
+        result = await self.session.execute(stmt)
+        return result.scalars().one_or_none()
+
+
+class CrawlerSourceRepository(AsyncRepository):
     """Repository for crawler source lookups."""
 
     model_type = CrawlerSourceModel
-    id_attribute = "crawler_source_id"
 
     async def get_by_suffix(self, suffix: str) -> CrawlerSourceModel | None:
         """Look up a source by suffix, case-insensitive."""
@@ -26,11 +48,10 @@ class CrawlerSourceRepository(SQLAlchemyAsyncRepository[CrawlerSourceModel]):
         )
 
 
-class FeatureRepository(SQLAlchemyAsyncRepository[FeatureSourceModel]):
+class FeatureRepository(AsyncRepository):
     """Repository for feature lookups."""
 
     model_type = FeatureSourceModel
-    id_attribute = "identifier"
 
     async def feature_lookup(self, source_suffix: str, identifier: str) -> FeatureSourceModel | None:
         """Look up a feature by source suffix and identifier.
@@ -71,11 +92,10 @@ class FeatureRepository(SQLAlchemyAsyncRepository[FeatureSourceModel]):
         return list(await self.list(statement=stmt))
 
 
-class FlowlineRepository(SQLAlchemyAsyncRepository[FlowlineModel]):
+class FlowlineRepository(AsyncRepository):
     """Repository for flowline lookups."""
 
     model_type = FlowlineModel
-    id_attribute = "nhdplus_comid"
 
     async def list_all(self, limit: int = 0, offset: int = 0) -> list[FlowlineModel]:
         """List flowlines with optional pagination."""
@@ -257,11 +277,10 @@ class FlowlineRepository(SQLAlchemyAsyncRepository[FlowlineModel]):
         return (float(row[0]), float(row[1]))
 
 
-class CatchmentRepository(SQLAlchemyAsyncRepository[CatchmentModel]):
+class CatchmentRepository(AsyncRepository):
     """Repository for catchment lookups."""
 
     model_type = CatchmentModel
-    id_attribute = "featureid"
 
     async def get_by_point(self, wkt_point: str) -> CatchmentModel | None:
         """Find a catchment by spatial intersection with a WKT point."""

--- a/src/nldi/errors.py
+++ b/src/nldi/errors.py
@@ -3,6 +3,7 @@
 """RFC 9457 Problem Details error handlers."""
 
 import logging
+import traceback
 import uuid
 from http import HTTPStatus
 from typing import Any
@@ -61,10 +62,16 @@ def gateway_timeout_handler(_request: Request[Any, Any, Any], exc: PyGeoAPITimeo
     return Response(content=body, status_code=504, media_type=MediaType.PROBLEM_JSON)
 
 
+def _short_tb(exc: Exception, frames: int = 3) -> str:
+    """Format a short traceback: last N frames + exception line."""
+    tb = traceback.format_tb(exc.__traceback__)
+    return "".join(tb[-frames:]) + "".join(traceback.format_exception_only(type(exc), exc))
+
+
 def db_unavailable_handler(_request: Request[Any, Any, Any], exc: Exception) -> Response[dict[str, Any]]:
     """Return a 503 Service Unavailable for database connection errors."""
     ref = uuid.uuid4().hex[:8]
-    logger.exception("Database unavailable [%s]", ref)
+    logger.error("Database unavailable [%s]\n%s", ref, _short_tb(exc))
     body: dict[str, Any] = {
         "type": "about:blank",
         "title": "Service Unavailable",

--- a/start_nldi_server.sh
+++ b/start_nldi_server.sh
@@ -14,4 +14,5 @@ exec uvicorn \
         --host ${CONTAINER_HOST} \
         --port ${CONTAINER_PORT} \
         --workers ${WSGI_WORKERS} \
+        --timeout-graceful-shutdown 5 \
         nldi.asgi:app

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -84,3 +84,27 @@ async def db_session(db_url):
     async with session_factory() as session:
         yield session
     await engine.dispose()
+
+
+@pytest.fixture()
+def app_client(db_url):
+    """Provide a TestClient wired to the real containerized DB."""
+    import os
+
+    from litestar.testing import TestClient
+
+    from nldi.asgi import create_app
+    from nldi.db import get_engine, provide_db_session
+
+    # Point engine at the test container
+    os.environ["NLDI_DB_HOST"] = "unused"  # get_engine won't be called — we override
+    import nldi.db as db_mod
+
+    db_mod._engine = create_async_engine(db_url, pool_pre_ping=True)
+
+    app = create_app()
+    with TestClient(app=app) as client:
+        yield client
+
+    # Reset engine singleton
+    db_mod._engine = None

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -94,7 +94,6 @@ def app_client(db_url):
     from litestar.testing import TestClient
 
     from nldi.asgi import create_app
-    from nldi.db import get_engine, provide_db_session
 
     # Point engine at the test container
     os.environ["NLDI_DB_HOST"] = "unused"  # get_engine won't be called — we override

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -94,16 +94,18 @@ def app_client(db_url):
     from litestar.testing import TestClient
 
     from nldi.asgi import create_app
+    from nldi.db import get_engine
 
     # Point engine at the test container
-    os.environ["NLDI_DB_HOST"] = "unused"  # get_engine won't be called — we override
-    import nldi.db as db_mod
-
-    db_mod._engine = create_async_engine(db_url, pool_pre_ping=True)
+    get_engine.cache_clear()
+    os.environ["NLDI_DB_HOST"] = db_url.split("@")[1].split(":")[0]
+    os.environ["NLDI_DB_PORT"] = db_url.split(":")[-1].split("/")[0]
+    os.environ["NLDI_DB_NAME"] = db_url.split("/")[-1]
+    os.environ["NLDI_DB_USERNAME"] = db_url.split("//")[1].split(":")[0]
+    os.environ["NLDI_DB_PASSWORD"] = db_url.split("//")[1].split(":")[1].split("@")[0]
 
     app = create_app()
     with TestClient(app=app) as client:
         yield client
 
-    # Reset engine singleton
-    db_mod._engine = None
+    get_engine.cache_clear()

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -1,0 +1,104 @@
+"""Integration tests via TestClient — full stack through real DB.
+
+Exercises route → DI → handler → repo → real DB → response.
+Catches interface mismatches that unit tests with fakes miss.
+"""
+
+import pytest
+
+
+@pytest.mark.integration
+class TestEndpointIntegration:
+    def test_list_sources(self, app_client):
+        r = app_client.get("/api/nldi/linked-data?f=json")
+        assert r.status_code == 200
+        body = r.json()
+        assert isinstance(body, list)
+        assert len(body) > 0
+        assert "source" in body[0]
+
+    def test_single_feature_by_comid(self, app_client):
+        r = app_client.get("/api/nldi/linked-data/comid/13293396?f=json")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["type"] == "FeatureCollection"
+        assert len(body["features"]) == 1
+
+    def test_single_feature_by_source(self, app_client):
+        r = app_client.get("/api/nldi/linked-data/wqp/USGS-05427930?f=json")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["type"] == "FeatureCollection"
+
+    def test_comid_position(self, app_client):
+        r = app_client.get("/api/nldi/linked-data/comid/position?coords=POINT(-89.4423056 43.1402778)&f=json")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["type"] == "FeatureCollection"
+
+    def test_comid_position_not_found(self, app_client):
+        r = app_client.get("/api/nldi/linked-data/comid/position?coords=POINT(0 0)&f=json")
+        assert r.status_code == 404
+
+    def test_comid_position_malformed_coords(self, app_client):
+        r = app_client.get("/api/nldi/linked-data/comid/position?coords=POINT&f=json")
+        assert r.status_code == 400
+
+    def test_nav_modes(self, app_client):
+        r = app_client.get("/api/nldi/linked-data/comid/13293396/navigation?f=json")
+        assert r.status_code == 200
+        body = r.json()
+        assert len(body) == 4
+
+    def test_nav_flowlines(self, app_client):
+        r = app_client.get("/api/nldi/linked-data/comid/13293396/navigation/DM/flowlines?distance=10&f=json")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["type"] == "FeatureCollection"
+
+    def test_nav_features(self, app_client):
+        r = app_client.get("/api/nldi/linked-data/comid/13293396/navigation/DM/wqp?distance=50&f=json")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["type"] == "FeatureCollection"
+
+    def test_nav_from_source_feature(self, app_client):
+        r = app_client.get("/api/nldi/linked-data/wqp/USGS-05427930/navigation/DM/flowlines?distance=10&f=json")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["type"] == "FeatureCollection"
+
+    def test_list_features_by_source(self, app_client):
+        r = app_client.get("/api/nldi/linked-data/wqp?f=json")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["type"] == "FeatureCollection"
+        assert len(body["features"]) > 0
+
+    def test_list_comids_with_pagination(self, app_client):
+        r = app_client.get("/api/nldi/linked-data/comid?limit=10&offset=10&f=json")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["type"] == "FeatureCollection"
+        assert len(body["features"]) == 10
+
+    def test_basin(self, app_client):
+        r = app_client.get("/api/nldi/linked-data/comid/13293396/basin?f=json")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["type"] == "FeatureCollection"
+
+    def test_feature_not_found(self, app_client):
+        r = app_client.get("/api/nldi/linked-data/wqp/DOES-NOT-EXIST?f=json")
+        assert r.status_code == 404
+
+    def test_source_not_found(self, app_client):
+        r = app_client.get("/api/nldi/linked-data/nosuchsource/anything?f=json")
+        assert r.status_code == 404
+
+    def test_jsonld(self, app_client):
+        r = app_client.get("/api/nldi/linked-data/wqp/USGS-05427930?f=jsonld")
+        assert r.status_code == 200
+        assert "application/ld+json" in r.headers["content-type"]
+        body = r.json()
+        assert "@context" in body

--- a/tests/integration/test_list_sources.py
+++ b/tests/integration/test_list_sources.py
@@ -1,7 +1,6 @@
 """Integration tests for GET /linked-data (list sources)."""
 
 import pytest
-import sqlalchemy
 from sqlalchemy import text
 
 
@@ -16,11 +15,10 @@ async def test_sources_table_has_data(db_session):
 @pytest.mark.integration
 async def test_list_sources_from_repo(db_session):
     """Verify CrawlerSourceRepository returns sources with expected shape."""
-    from nldi.db.models import CrawlerSourceModel
     from nldi.db.repos import CrawlerSourceRepository
 
     repo = CrawlerSourceRepository(session=db_session)
-    sources = await repo.list(sqlalchemy.select(CrawlerSourceModel))
+    sources = await repo.list()
     assert len(sources) > 0
     for s in sources:
         assert s.source_suffix is not None

--- a/tests/integration/test_list_sources.py
+++ b/tests/integration/test_list_sources.py
@@ -1,6 +1,7 @@
 """Integration tests for GET /linked-data (list sources)."""
 
 import pytest
+import sqlalchemy
 from sqlalchemy import text
 
 
@@ -15,10 +16,11 @@ async def test_sources_table_has_data(db_session):
 @pytest.mark.integration
 async def test_list_sources_from_repo(db_session):
     """Verify CrawlerSourceRepository returns sources with expected shape."""
+    from nldi.db.models import CrawlerSourceModel
     from nldi.db.repos import CrawlerSourceRepository
 
     repo = CrawlerSourceRepository(session=db_session)
-    sources = await repo.list()
+    sources = await repo.list(sqlalchemy.select(CrawlerSourceModel))
     assert len(sources) > 0
     for s in sources:
         assert s.source_suffix is not None

--- a/tests/integration/test_navigation.py
+++ b/tests/integration/test_navigation.py
@@ -1,7 +1,6 @@
 """Integration tests for flowline navigation."""
 
 import pytest
-from sqlalchemy import text
 
 
 @pytest.mark.integration

--- a/tests/integration/test_repos.py
+++ b/tests/integration/test_repos.py
@@ -1,0 +1,84 @@
+"""Integration tests for repository methods against real DB.
+
+Covers repo methods called by controllers that were previously
+only tested with fakes.
+"""
+
+import pytest
+import sqlalchemy
+
+from nldi.db.models import CatchmentModel, CrawlerSourceModel, FlowlineModel
+from nldi.db.repos import (
+    CatchmentRepository,
+    CrawlerSourceRepository,
+    FeatureRepository,
+    FlowlineRepository,
+)
+
+KNOWN_COMID = 13293396
+KNOWN_SOURCE = "wqp"
+KNOWN_FEATURE = "USGS-05427930"
+
+
+@pytest.mark.integration
+class TestCrawlerSourceRepo:
+    async def test_list_all(self, db_session):
+        repo = CrawlerSourceRepository(session=db_session)
+        sources = await repo.list()
+        assert len(sources) > 0
+
+    async def test_get_by_suffix(self, db_session):
+        repo = CrawlerSourceRepository(session=db_session)
+        source = await repo.get_by_suffix(KNOWN_SOURCE)
+        assert source is not None
+        assert source.source_suffix.lower() == KNOWN_SOURCE
+
+    async def test_get_by_suffix_case_insensitive(self, db_session):
+        repo = CrawlerSourceRepository(session=db_session)
+        source = await repo.get_by_suffix("WQP")
+        assert source is not None
+
+
+@pytest.mark.integration
+class TestFlowlineRepo:
+    async def test_get_one_or_none_by_comid(self, db_session):
+        repo = FlowlineRepository(session=db_session)
+        flowline = await repo.get_one_or_none(FlowlineModel.nhdplus_comid == KNOWN_COMID)
+        assert flowline is not None
+        assert flowline.nhdplus_comid == KNOWN_COMID
+
+    async def test_get_one_or_none_missing(self, db_session):
+        repo = FlowlineRepository(session=db_session)
+        flowline = await repo.get_one_or_none(FlowlineModel.nhdplus_comid == -1)
+        assert flowline is None
+
+    async def test_get_measure_and_reachcode(self, db_session):
+        repo = FlowlineRepository(session=db_session)
+        measure, reachcode = await repo.get_measure_and_reachcode(
+            KNOWN_COMID, "POINT(-89.4423056 43.1402778)"
+        )
+        assert measure is not None
+        assert reachcode is not None
+
+
+@pytest.mark.integration
+class TestFeatureRepo:
+    async def test_feature_lookup(self, db_session):
+        repo = FeatureRepository(session=db_session)
+        feat = await repo.feature_lookup(KNOWN_SOURCE, KNOWN_FEATURE)
+        assert feat is not None
+        assert feat.identifier == KNOWN_FEATURE
+
+    async def test_list_by_source(self, db_session):
+        repo = FeatureRepository(session=db_session)
+        features = await repo.list_by_source(KNOWN_SOURCE, limit=5)
+        assert len(features) > 0
+        assert len(features) <= 5
+
+
+@pytest.mark.integration
+class TestCatchmentRepo:
+    async def test_get_by_point(self, db_session):
+        repo = CatchmentRepository(session=db_session)
+        catchment = await repo.get_by_point("POINT(-89.4423056 43.1402778)")
+        assert catchment is not None

--- a/tests/integration/test_repos.py
+++ b/tests/integration/test_repos.py
@@ -5,9 +5,8 @@ only tested with fakes.
 """
 
 import pytest
-import sqlalchemy
 
-from nldi.db.models import CatchmentModel, CrawlerSourceModel, FlowlineModel
+from nldi.db.models import FlowlineModel
 from nldi.db.repos import (
     CatchmentRepository,
     CrawlerSourceRepository,

--- a/tests/integration/test_single_feature.py
+++ b/tests/integration/test_single_feature.py
@@ -1,6 +1,5 @@
 """Integration tests for GET /linked-data/{source}/{identifier} (single feature)."""
 
-import os
 
 import pytest
 from sqlalchemy import text

--- a/tests/parity/test_parity.py
+++ b/tests/parity/test_parity.py
@@ -10,7 +10,6 @@ from .conftest import (
     JAVA_BASE,
     PY_BASE,
     load_fixture,
-    normalize_comid,
     normalize_urls,
     strip_geometry,
     summarize_collection,

--- a/tests/system/test_smoke.py
+++ b/tests/system/test_smoke.py
@@ -148,3 +148,7 @@ class TestHydrolocation:
         assert r.status_code == 200
         body = r.json()
         assert body["type"] == "FeatureCollection"
+
+    def test_comid_position_nebraska(self, client):
+        r = client.get("linked-data/comid/position?coords=POINT(-101.6 41.58)&f=json")
+        assert r.status_code == 404

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -110,11 +110,13 @@ class FakeFlowlineRepository:
     async def get_one_or_none(self, *args, **kwargs) -> FakeFlowlineModel | None:
         """Find a flowline by comid."""
         comid = kwargs.get("nhdplus_comid")
-        if comid is None:
-            return None
-        for f in self._flowlines:
-            if f.nhdplus_comid == int(comid):
-                return f
+        if comid is not None:
+            for f in self._flowlines:
+                if f.nhdplus_comid == int(comid):
+                    return f
+        # Positional filter: return first flowline if any exist
+        if args and self._flowlines:
+            return self._flowlines[0]
         return None
 
     async def list_all(self, limit: int = 0, offset: int = 0) -> list:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -119,6 +119,13 @@ class FakeFlowlineRepository:
             return self._flowlines[0]
         return None
 
+    async def get_by_comid(self, comid: int) -> FakeFlowlineModel | None:
+        """Find a flowline by comid."""
+        for f in self._flowlines:
+            if f.nhdplus_comid == int(comid):
+                return f
+        return None
+
     async def list_all(self, limit: int = 0, offset: int = 0) -> list:
         """List flowlines with pagination."""
         results = self._flowlines[offset:]

--- a/tests/unit/test_geojson.py
+++ b/tests/unit/test_geojson.py
@@ -6,7 +6,7 @@ import msgspec
 
 
 def test_feature_serializes():
-    from nldi.geojson import Feature, FeatureCollection, Point
+    from nldi.geojson import Feature, Point
 
     f = Feature(
         geometry=Point(coordinates=(-89.509, 43.087)),

--- a/tests/unit/test_pygeoapi_client.py
+++ b/tests/unit/test_pygeoapi_client.py
@@ -4,7 +4,7 @@ import pytest
 
 
 def test_client_imports():
-    from nldi.pygeoapi import PyGeoAPIClient, PyGeoAPIError, PyGeoAPITimeoutError
+    from nldi.pygeoapi import PyGeoAPIClient
 
     assert PyGeoAPIClient is not None
 

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -30,7 +30,6 @@ def test_health_check():
         assert body["server"]["status"] == "online"
         assert "no-cache" in r.headers.get("cache-control", "")
 
-import pytest
 
 
 def test_cors_headers_on_response():

--- a/tests/unit/test_split_catchment.py
+++ b/tests/unit/test_split_catchment.py
@@ -1,6 +1,5 @@
 """Unit tests for split catchment building blocks."""
 
-import pytest
 
 
 async def test_splitcatchment_client_returns_feature(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -3,35 +3,6 @@ revision = 3
 requires-python = ">=3.11, <4.0"
 
 [[package]]
-name = "advanced-alchemy"
-version = "1.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "alembic" },
-    { name = "greenlet" },
-    { name = "sqlalchemy" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/fb/5d629e83e7e93bbd9c3e77c17fbdf34f79e2b2c0365238565b9afbd047aa/advanced_alchemy-1.9.1.tar.gz", hash = "sha256:c2f2025875bc582fb13aa511af79b189dc80ae2fd70a7f590ed0d0db8634d097", size = 1143288, upload-time = "2026-03-26T01:39:08.185Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/af/0d8cfa503c9818ad9fe9eed2c89108aa0d0f3c7c967015951b1780a16061/advanced_alchemy-1.9.1-py3-none-any.whl", hash = "sha256:270f710793842f70c75d1f383367ebb23e3c1ca78dab0610f2d4301fcf8c188e", size = 315022, upload-time = "2026-03-26T01:39:06.558Z" },
-]
-
-[[package]]
-name = "alembic"
-version = "1.18.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mako" },
-    { name = "sqlalchemy" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
-]
-
-[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -828,18 +799,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mako"
-version = "1.3.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
-]
-
-[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1147,7 +1106,6 @@ name = "nldi-py"
 version = "3.0.0.dev0"
 source = { editable = "." }
 dependencies = [
-    { name = "advanced-alchemy" },
     { name = "asyncpg" },
     { name = "geoalchemy2" },
     { name = "litestar", extra = ["standard"] },
@@ -1169,7 +1127,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "advanced-alchemy", specifier = ">=1.8.0,<2" },
     { name = "asyncpg", specifier = ">=0.30.0,<1" },
     { name = "geoalchemy2", specifier = ">=0.16.0,<0.17" },
     { name = "litestar", extras = ["standard"], specifier = ">=2.21.0,<3" },


### PR DESCRIPTION
See [spec](docs/specs/remove-advanced-alchemy.md).

## Plan
1. Engine singleton + session provider ✅
2. Repository base class + migrate 4 repos
3. Update DI providers
4. Rewire asgi.py (remove plugin, simplify exception handlers)
5. Update integration test conftest
6. Remove advanced-alchemy from pyproject.toml
7. Fit and finish — docstrings, docs, load test verification