### PR TITLE
Fix connection leak on task cancellation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -49,6 +49,25 @@ tasks:
       NLDI_TEST_URL: '{{.NLDI_TEST_URL | default "http://localhost:8000/api/nldi"}}'
       DURATION: '{{.DURATION | default "5m"}}'
 
+  test:load:clean:
+    desc: Run load test with reduced users and longer timeout — minimizes mid-request cancellations
+    cmds:
+      - mkdir -p tests/load/results
+      - >
+        uv run locust
+        -f tests/load/locustfile.py
+        --host {{.NLDI_TEST_URL}}
+        --users 10
+        --spawn-rate 1
+        --run-time {{.DURATION}}
+        --stop-timeout 120
+        --headless
+        --csv tests/load/results/report-clean
+        --html tests/load/results/report-clean.html
+    vars:
+      NLDI_TEST_URL: '{{.NLDI_TEST_URL | default "http://localhost:8000/api/nldi"}}'
+      DURATION: '{{.DURATION | default "2m"}}'
+
   test:parity:
     desc: Run parity tests (requires running app — task dev)
     cmds:

--- a/src/nldi/db/__init__.py
+++ b/src/nldi/db/__init__.py
@@ -60,4 +60,8 @@ async def provide_db_session() -> AsyncGenerator[AsyncSession, None]:
     try:
         yield session
     finally:
-        await asyncio.shield(asyncio.ensure_future(session.close()))
+        # Fire-and-forget: schedule close on the event loop without awaiting.
+        # CancelledError cannot interrupt task creation, so the close is
+        # guaranteed to run on the next event loop iteration regardless of
+        # whether this generator was cancelled or completed normally.
+        asyncio.ensure_future(session.close())

--- a/src/nldi/db/__init__.py
+++ b/src/nldi/db/__init__.py
@@ -7,6 +7,7 @@ guarantees rollback+close on error or client disconnect, preventing
 zombie connections in the pool.
 """
 
+import asyncio
 from collections.abc import AsyncGenerator
 from functools import lru_cache
 
@@ -46,8 +47,17 @@ def get_cancel_engine() -> AsyncEngine:
 async def provide_db_session() -> AsyncGenerator[AsyncSession, None]:
     """Provide an async session with guaranteed cleanup.
 
-    SQLAlchemy's AsyncSession.__aexit__ handles cancellation-safe close
-    internally via asyncio.shield. We let it do that and stay out of the way.
+    Bypasses AsyncSession.__aexit__ for the close call. When a handler task
+    is cancelled (client disconnect), Litestar throws CancelledError into this
+    generator via athrow(). AsyncSession.__aexit__ creates a close task and
+    shields it, but the CancelledError propagates out before the task runs,
+    orphaning it. The connection is never returned to the pool.
+
+    By owning the close in a finally block with asyncio.shield, we ensure the
+    connection is returned even when CancelledError is in flight.
     """
-    async with AsyncSession(get_engine()) as session:
+    session = AsyncSession(get_engine())
+    try:
         yield session
+    finally:
+        await asyncio.shield(asyncio.ensure_future(session.close()))

--- a/src/nldi/db/__init__.py
+++ b/src/nldi/db/__init__.py
@@ -7,7 +7,6 @@ guarantees rollback+close on error or client disconnect, preventing
 zombie connections in the pool.
 """
 
-import asyncio
 from collections.abc import AsyncGenerator
 from functools import lru_cache
 
@@ -47,16 +46,9 @@ def get_cancel_engine() -> AsyncEngine:
 async def provide_db_session() -> AsyncGenerator[AsyncSession, None]:
     """Provide an async session with guaranteed cleanup.
 
-    On cancellation (client disconnect), the session connection may be in an
-    unknown state after pg_cancel_backend fires. We invalidate it so the pool
-    discards it and decrements checked_out, rather than attempting a clean
-    return that may silently fail.
+    SQLAlchemy's AsyncSession.__aexit__ handles close via asyncio.shield.
+    The handler task is never cancelled — QueryCanceledError from pg_cancel_backend
+    propagates naturally, so the session always closes via the normal error path.
     """
-    session = AsyncSession(get_engine())
-    try:
+    async with AsyncSession(get_engine()) as session:
         yield session
-    except asyncio.CancelledError:
-        asyncio.ensure_future(session.invalidate())
-        raise
-    finally:
-        asyncio.ensure_future(session.close())

--- a/src/nldi/db/__init__.py
+++ b/src/nldi/db/__init__.py
@@ -47,21 +47,16 @@ def get_cancel_engine() -> AsyncEngine:
 async def provide_db_session() -> AsyncGenerator[AsyncSession, None]:
     """Provide an async session with guaranteed cleanup.
 
-    Bypasses AsyncSession.__aexit__ for the close call. When a handler task
-    is cancelled (client disconnect), Litestar throws CancelledError into this
-    generator via athrow(). AsyncSession.__aexit__ creates a close task and
-    shields it, but the CancelledError propagates out before the task runs,
-    orphaning it. The connection is never returned to the pool.
-
-    By owning the close in a finally block with asyncio.shield, we ensure the
-    connection is returned even when CancelledError is in flight.
+    On cancellation (client disconnect), the session connection may be in an
+    unknown state after pg_cancel_backend fires. We invalidate it so the pool
+    discards it and decrements checked_out, rather than attempting a clean
+    return that may silently fail.
     """
     session = AsyncSession(get_engine())
     try:
         yield session
+    except asyncio.CancelledError:
+        asyncio.ensure_future(session.invalidate())
+        raise
     finally:
-        # Fire-and-forget: schedule close on the event loop without awaiting.
-        # CancelledError cannot interrupt task creation, so the close is
-        # guaranteed to run on the next event loop iteration regardless of
-        # whether this generator was cancelled or completed normally.
         asyncio.ensure_future(session.close())

--- a/src/nldi/middleware.py
+++ b/src/nldi/middleware.py
@@ -99,7 +99,14 @@ def disconnect_guard_factory(app: ASGIApp) -> ASGIApp:
         handler = asyncio.create_task(app(scope, receive, send))
 
         async def watch_disconnect() -> None:
-            """Poll receive for client disconnect."""
+            """Poll receive for client disconnect.
+
+            Calls pg_cancel_backend to interrupt the in-flight DB query, then
+            returns. Does NOT cancel the handler task — the QueryCanceledError
+            raised by Postgres propagates naturally through SQLAlchemy and
+            Litestar's error handler, allowing the session to close via the
+            normal error path and return the connection to the pool cleanly.
+            """
             while True:
                 msg = await receive()
                 if msg["type"] == "http.disconnect":
@@ -108,15 +115,12 @@ def disconnect_guard_factory(app: ASGIApp) -> ASGIApp:
                             await repo.cancel_running_query()
                         except Exception:  # noqa: S110
                             pass
-                    handler.cancel()
                     return
 
         watcher = asyncio.create_task(watch_disconnect())
 
         try:
             await handler
-        except asyncio.CancelledError:
-            logger.warning("Request cancelled by client disconnect")
         finally:
             watcher.cancel()
             try:


### PR DESCRIPTION
Pool connections not returned when handler tasks are cancelled by the disconnect guard. Diagnosed via load testing with pool health endpoint.