### PR TITLE
Switch DB driver from asyncpg to psycopg3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "litestar[standard]>=2.21.0,<3",
   "uvicorn>=0.34.0,<0.35",
   "sqlalchemy[asyncio]>=2.0,<3",
-  "asyncpg>=0.30.0,<1",
+  "psycopg[async]>=3.1,<4",
   "geoalchemy2>=0.16.0,<0.17",
   "msgspec>=0.19.0,<0.20",
 ]

--- a/src/nldi/config.py
+++ b/src/nldi/config.py
@@ -48,7 +48,7 @@ def get_database_url() -> str:
     if missing:
         raise RuntimeError(f"Required database env var(s) not set: {', '.join(missing)}")
 
-    return f"postgresql+asyncpg://{user}:{password}@{host}:{port}/{name}"
+    return f"postgresql+psycopg://{user}:{password}@{host}:{port}/{name}"
 
 
 def get_base_url() -> str:

--- a/src/nldi/db/__init__.py
+++ b/src/nldi/db/__init__.py
@@ -25,10 +25,7 @@ def get_engine() -> AsyncEngine:
         max_overflow=30,
         pool_timeout=60,
         connect_args={
-            "server_settings": {
-                "statement_timeout": "120s",
-                "idle_in_transaction_session_timeout": "30s",
-            }
+            "options": "-c statement_timeout=120000 -c idle_in_transaction_session_timeout=30000"
         },
     )
 

--- a/src/nldi/db/repos.py
+++ b/src/nldi/db/repos.py
@@ -314,23 +314,25 @@ class CatchmentRepository(AsyncRepository):
     model_type = CatchmentModel
 
     async def cancel_running_query(self) -> None:
-        """Terminate the in-flight basin query via pg_terminate_backend.
+        """Close the underlying connection to force-kill the basin query.
 
-        Uses terminate instead of cancel because GEOS geometry operations
-        (ST_Union, ST_Simplify) are slow to respond to pg_cancel_backend.
-        Terminate is immediate — the connection is discarded by the pool,
-        but checked_out is decremented right away.
+        pg_terminate_backend is insufficient — GEOS geometry operations
+        (ST_Union, ST_Simplify) ignore Postgres interrupt signals for minutes.
+        Closing the TCP connection causes Postgres to detect a lost client and
+        kill the backend at the OS level immediately, the same mechanism Java's
+        thread-interrupt model uses.
         """
-        pid = self._cancel_pid
-        if not pid:
+        if not self._cancel_pid:
             return
         import logging
-        logging.getLogger(__name__).info("Terminating basin query on backend PID %s", pid)
-        from . import get_cancel_engine
-
-        async with get_cancel_engine().connect() as conn:
-            await conn.execute(sqlalchemy.text("SELECT pg_terminate_backend(:pid)"), {"pid": pid})
-            await conn.commit()
+        logger = logging.getLogger(__name__)
+        logger.info("Closing connection for basin PID %s", self._cancel_pid)
+        try:
+            conn = await self.session.connection()
+            raw = await conn.get_raw_connection()
+            await raw.driver_connection.close()
+        except Exception as e:
+            logger.warning("Failed to close basin connection: %s", e)
 
     async def get_by_point(self, wkt_point: str) -> CatchmentModel | None:
         """Find a catchment by spatial intersection with a WKT point."""

--- a/src/nldi/db/repos.py
+++ b/src/nldi/db/repos.py
@@ -24,7 +24,18 @@ class AsyncRepository:
         self.session = session
 
     async def cancel_running_query(self) -> None:
-        """Cancel the in-flight query via pg_cancel_backend, if any."""
+        """Cancel the in-flight query via pg_cancel_backend, if any.
+
+        Uses pg_cancel_backend rather than closing the connection directly.
+        For pure SQL queries (navigation CTEs), pg_cancel_backend responds in
+        milliseconds and allows the connection to recover and be returned to
+        the pool for reuse. Closing the connection would also work but discards
+        it, forcing a new connection on next checkout — expensive under load.
+
+        CatchmentRepository overrides this with a direct connection close
+        because GEOS geometry operations (ST_Union) ignore pg_cancel_backend
+        for minutes and require OS-level termination.
+        """
         pid = self._cancel_pid
         if not pid:
             return
@@ -316,11 +327,17 @@ class CatchmentRepository(AsyncRepository):
     async def cancel_running_query(self) -> None:
         """Close the underlying connection to force-kill the basin query.
 
-        pg_terminate_backend is insufficient — GEOS geometry operations
-        (ST_Union, ST_Simplify) ignore Postgres interrupt signals for minutes.
+        Overrides the base pg_cancel_backend approach because GEOS geometry
+        operations (ST_Union, ST_Simplify) ignore Postgres interrupt signals
+        for minutes — making pg_cancel_backend ineffective for basin queries.
+
         Closing the TCP connection causes Postgres to detect a lost client and
-        kill the backend at the OS level immediately, the same mechanism Java's
-        thread-interrupt model uses.
+        kill the backend at the OS level immediately. This is the same mechanism
+        the Java implementation relies on: a thread interrupt closes the JDBC
+        socket, which Postgres detects and uses to terminate the backend.
+
+        The connection is discarded rather than returned to the pool, but that
+        is acceptable — a new connection is cheaper than holding a stuck one.
         """
         if not self._cancel_pid:
             return

--- a/src/nldi/db/repos.py
+++ b/src/nldi/db/repos.py
@@ -28,6 +28,8 @@ class AsyncRepository:
         pid = self._cancel_pid
         if not pid:
             return
+        import logging
+        logging.getLogger(__name__).info("Cancelling query on backend PID %s", pid)
         from . import get_cancel_engine
 
         async with get_cancel_engine().connect() as conn:

--- a/src/nldi/db/repos.py
+++ b/src/nldi/db/repos.py
@@ -40,7 +40,7 @@ class AsyncRepository:
         if not pid:
             return
         import logging
-        logging.getLogger(__name__).info("Cancelling query on backend PID %s", pid)
+        logging.getLogger(__name__).debug("Cancelling query on backend PID %s", pid)
         from . import get_cancel_engine
 
         async with get_cancel_engine().connect() as conn:
@@ -343,7 +343,7 @@ class CatchmentRepository(AsyncRepository):
             return
         import logging
         logger = logging.getLogger(__name__)
-        logger.info("Closing connection for basin PID %s", self._cancel_pid)
+        logger.debug("Closing connection for basin PID %s", self._cancel_pid)
         try:
             conn = await self.session.connection()
             raw = await conn.get_raw_connection()

--- a/src/nldi/db/repos.py
+++ b/src/nldi/db/repos.py
@@ -313,6 +313,25 @@ class CatchmentRepository(AsyncRepository):
 
     model_type = CatchmentModel
 
+    async def cancel_running_query(self) -> None:
+        """Terminate the in-flight basin query via pg_terminate_backend.
+
+        Uses terminate instead of cancel because GEOS geometry operations
+        (ST_Union, ST_Simplify) are slow to respond to pg_cancel_backend.
+        Terminate is immediate — the connection is discarded by the pool,
+        but checked_out is decremented right away.
+        """
+        pid = self._cancel_pid
+        if not pid:
+            return
+        import logging
+        logging.getLogger(__name__).info("Terminating basin query on backend PID %s", pid)
+        from . import get_cancel_engine
+
+        async with get_cancel_engine().connect() as conn:
+            await conn.execute(sqlalchemy.text("SELECT pg_terminate_backend(:pid)"), {"pid": pid})
+            await conn.commit()
+
     async def get_by_point(self, wkt_point: str) -> CatchmentModel | None:
         """Find a catchment by spatial intersection with a WKT point."""
         point = geoalchemy2.WKTElement(wkt_point, srid=4269)

--- a/src/nldi/health.py
+++ b/src/nldi/health.py
@@ -23,7 +23,7 @@ async def check_db() -> dict:
     sanitized_host = ".".join(host.split(".")[1:]) if "." in host else host
     try:
         url = get_database_url()
-        engine = create_async_engine(url, connect_args={"timeout": 3})
+        engine = create_async_engine(url, connect_args={"connect_timeout": 3})
         async with engine.connect() as conn:
             await conn.execute(text("SELECT 1"))
         await engine.dispose()

--- a/src/nldi/middleware.py
+++ b/src/nldi/middleware.py
@@ -108,15 +108,6 @@ def disconnect_guard_factory(app: ASGIApp) -> ASGIApp:
                             await repo.cancel_running_query()
                         except Exception:  # noqa: S110
                             pass
-                    try:
-                        from .db import get_engine
-                        pool = get_engine().pool
-                        logger.info(
-                            "Pool on disconnect: size=%d in=%d out=%d overflow=%d",
-                            pool.size(), pool.checkedin(), pool.checkedout(), pool.overflow(),  # ty: ignore[unresolved-attribute]
-                        )
-                    except Exception as e:
-                        logger.warning("Pool stats unavailable on disconnect: %s", e)
                     handler.cancel()
                     return
 

--- a/src/nldi/middleware.py
+++ b/src/nldi/middleware.py
@@ -115,8 +115,8 @@ def disconnect_guard_factory(app: ASGIApp) -> ASGIApp:
                             "Pool on disconnect: size=%d in=%d out=%d overflow=%d",
                             pool.size(), pool.checkedin(), pool.checkedout(), pool.overflow(),  # ty: ignore[unresolved-attribute]
                         )
-                    except Exception:  # noqa: S110
-                        pass
+                    except Exception as e:
+                        logger.warning("Pool stats unavailable on disconnect: %s", e)
                     handler.cancel()
                     return
 

--- a/src/nldi/middleware.py
+++ b/src/nldi/middleware.py
@@ -108,6 +108,15 @@ def disconnect_guard_factory(app: ASGIApp) -> ASGIApp:
                             await repo.cancel_running_query()
                         except Exception:  # noqa: S110
                             pass
+                    try:
+                        from .db import get_engine
+                        pool = get_engine().pool
+                        logger.info(
+                            "Pool on disconnect: size=%d in=%d out=%d overflow=%d",
+                            pool.size(), pool.checkedin(), pool.checkedout(), pool.overflow(),  # ty: ignore[unresolved-attribute]
+                        )
+                    except Exception:  # noqa: S110
+                        pass
                     handler.cancel()
                     return
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,7 @@
 import logging
 import time
 
-import asyncpg
+import psycopg
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from testcontainers.core.container import DockerContainer
@@ -16,9 +16,11 @@ def _wait_for_db(host: str, port: int, user: str, password: str, dbname: str, ti
     import asyncio
 
     async def _try_query():
-        conn = await asyncpg.connect(host=host, port=port, user=user, password=password, database=dbname)
+        conn = await psycopg.AsyncConnection.connect(
+            host=host, port=port, user=user, password=password, dbname=dbname
+        )
         try:
-            await conn.fetch("SELECT 1 FROM nldi_data.crawler_source LIMIT 1")
+            await conn.execute("SELECT 1 FROM nldi_data.crawler_source LIMIT 1")
         finally:
             await conn.close()
 
@@ -73,7 +75,7 @@ def nldi_db_container():
 def db_url(nldi_db_container):
     """Build async database URL from container info."""
     c = nldi_db_container
-    return f"postgresql+asyncpg://{c['user']}:{c['password']}@{c['host']}:{c['port']}/{c['name']}"
+    return f"postgresql+psycopg://{c['user']}:{c['password']}@{c['host']}:{c['port']}/{c['name']}"
 
 
 @pytest.fixture()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -38,7 +38,7 @@ class TestDatabaseUrl:
         monkeypatch.setenv("NLDI_DB_NAME", "mydb")
         monkeypatch.setenv("NLDI_DB_USERNAME", "user")
         monkeypatch.setenv("NLDI_DB_PASSWORD", "secret")
-        assert get_database_url() == "postgresql+asyncpg://user:secret@dbhost:5433/mydb"
+        assert get_database_url() == "postgresql+psycopg://user:secret@dbhost:5433/mydb"
 
     def test_default_port(self, monkeypatch):
         monkeypatch.setenv("NLDI_DB_HOST", "dbhost")


### PR DESCRIPTION
Replace asyncpg with psycopg3 (native asyncio) to resolve connection pool leaks under task cancellation. asyncpg's greenlet bridge leaves connections in an unrecoverable state when tasks are cancelled mid-query; psycopg3 handles CancelledError predictably as a native coroutine driver.