### PR TITLE
Stream GeoJSON serialization on navigation endpoints

### DIFF
--- a/docs/specs/streaming-nav-responses.md
+++ b/docs/specs/streaming-nav-responses.md
@@ -1,0 +1,110 @@
+# Spec: Streaming navigation responses
+
+## Problem
+
+Navigation endpoints (`/flowlines`, `/{data_source}`) build a complete
+`FeatureCollection` in memory before writing any bytes to the client.
+For large result sets this means the client waits for full JSON
+serialization before receiving the first byte. Time-to-first-byte is
+poor even when the DB query itself is fast.
+
+## Solution
+
+Stream the GeoJSON `FeatureCollection` response by yielding the opening
+wrapper, then each serialized `Feature`, then the closing wrapper — as
+the in-memory result list is iterated. The DB query is unchanged; the
+full result list is materialized before streaming begins.
+
+---
+
+## Design
+
+### What changes
+
+A shared generator in `geojson.py`:
+
+```python
+def stream_feature_collection(features: list[Feature]) -> Iterator[bytes]:
+    yield b'{"type":"FeatureCollection","features":['
+    for i, feat in enumerate(features):
+        if i > 0:
+            yield b","
+        yield msgspec.json.encode(feat)
+    yield b"]}"
+```
+
+Both nav endpoints return a Litestar `Stream` instead of a `Response`:
+
+```python
+from litestar.response import Stream
+
+return Stream(stream_feature_collection(features), media_type=MediaType.GEOJSON)
+```
+
+### Connection pool safety
+
+By the time streaming starts, the DB query has returned and the session is
+closed. The pool connection is back in the pool before the first byte is
+sent. A client hangup mid-stream is a network event only — no DB state is
+involved. The disconnect guard's `_cancel_pid` is `None` by this point, so
+any watcher firing during streaming is a no-op.
+
+Streaming *improves* the pool story slightly: the connection is returned
+right after the query rather than being held while the full response is
+serialized.
+
+### What does not change
+
+- The DB query — `from_nav_query`, `from_trimmed_nav_query` still return
+  a fully materialized list. The DB connection is returned to the pool
+  before the first byte is streamed.
+- `excludeGeometry` — applied to the list before passing to the generator,
+  no change needed.
+- The disconnect guard — `_cancel_pid` is cleared after the query returns.
+  A client disconnect during streaming is a no-op cancel, handled cleanly.
+- The `jsonld` format path in `get_feature_navigation` — JSON-LD requires
+  a complete graph object; it is not streamed and remains a standard
+  `Response`.
+- Error handling before streaming starts — 4xx errors raised during
+  COMID resolution or parameter validation are returned normally before
+  any streaming begins.
+
+### Error handling caveat
+
+Once streaming starts the HTTP status `200` is already sent. An exception
+mid-stream (e.g. serialization error on a malformed geometry) will result
+in a truncated response rather than a clean error status. This is
+acceptable: the data is already in memory and serialization errors on
+`msgspec` structs are not expected in practice.
+
+---
+
+## Scope
+
+Only the two GeoJSON navigation endpoints:
+
+- `GET /{source}/{id}/navigation/{mode}/flowlines` (`get_flowline_navigation`)
+- `GET /{source}/{id}/navigation/{mode}/{data_source}` (`get_feature_navigation`)
+
+Basin and all non-navigation endpoints are out of scope.
+
+---
+
+## Testing
+
+- Unit: assert streamed bytes concatenate to valid GeoJSON with correct
+  feature count.
+- Unit: assert empty result streams to `{"type":"FeatureCollection","features":[]}`.
+- Existing integration tests cover the full endpoint response; verify they
+  still pass by joining streamed chunks and parsing JSON.
+
+---
+
+## Plan
+
+| Step | Description |
+|------|-------------|
+| 1 | Add `stream_feature_collection` generator to `geojson.py` |
+| 2 | Update `get_flowline_navigation` to return `Stream` |
+| 3 | Update `get_feature_navigation` GeoJSON path to return `Stream` |
+| 4 | Unit tests for the generator |

--- a/src/nldi/controllers/linked_data/__init__.py
+++ b/src/nldi/controllers/linked_data/__init__.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ...config import get_base_url
 from ...db.repos import CatchmentRepository, CrawlerSourceRepository, FeatureRepository, FlowlineRepository
-from ...geojson import Feature, FeatureCollection, Point, parse_geometry
+from ...geojson import Feature, FeatureCollection, Point, parse_geometry, stream_feature_collection
 from ...media import MediaType
 from ...negotiate import check_format
 from ...pygeoapi import PyGeoAPIClient

--- a/src/nldi/controllers/linked_data/navigation.py
+++ b/src/nldi/controllers/linked_data/navigation.py
@@ -11,7 +11,7 @@ from litestar.params import Dependency, Parameter
 from litestar.response import Stream
 
 from ...db.navigation import NAV_DIST_DEFAULTS, NavigationModes, navigation_query, trim_nav_query
-from ...jsonld import to_jsonld_graph
+from ...jsonld import stream_jsonld_graph
 from . import (
     CrawlerSourceRepository,
     DataSourceParam,
@@ -220,5 +220,5 @@ class NavigationController(Controller):
 
         if f == "jsonld":
             feature_dicts = [msgspec.to_builtins(feat) for feat in features]
-            return Response(content=to_jsonld_graph(feature_dicts), status_code=200, media_type=MediaType.JSONLD)
+            return Stream(stream_jsonld_graph(feature_dicts), media_type=MediaType.JSONLD)
         return Stream(stream_feature_collection(features), media_type=MediaType.GEOJSON)

--- a/src/nldi/controllers/linked_data/navigation.py
+++ b/src/nldi/controllers/linked_data/navigation.py
@@ -8,6 +8,7 @@ import msgspec
 from litestar import Controller, Response, get, head
 from litestar.exceptions import ClientException
 from litestar.params import Dependency, Parameter
+from litestar.response import Stream
 
 from ...db.navigation import NAV_DIST_DEFAULTS, NavigationModes, navigation_query, trim_nav_query
 from ...jsonld import to_jsonld_graph
@@ -28,6 +29,7 @@ from . import (
     check_format,
     get_base_url,
     parse_geometry,
+    stream_feature_collection,
 )
 
 _NAV_PATHS = [
@@ -176,7 +178,7 @@ class NavigationController(Controller):
             for f in features:
                 f.geometry = None
 
-        return Response(content=FeatureCollection(features=features), status_code=200, media_type=MediaType.GEOJSON)
+        return Stream(stream_feature_collection(features), media_type=MediaType.GEOJSON)
 
     @get("/{source_name:str}/{identifier:str}/navigation/{nav_mode:str}/{data_source:str}", tags=["by_sourceid"])
     async def get_feature_navigation(
@@ -219,4 +221,4 @@ class NavigationController(Controller):
         if f == "jsonld":
             feature_dicts = [msgspec.to_builtins(feat) for feat in features]
             return Response(content=to_jsonld_graph(feature_dicts), status_code=200, media_type=MediaType.JSONLD)
-        return Response(content=FeatureCollection(features=features), status_code=200, media_type=MediaType.GEOJSON)
+        return Stream(stream_feature_collection(features), media_type=MediaType.GEOJSON)

--- a/src/nldi/geojson.py
+++ b/src/nldi/geojson.py
@@ -8,6 +8,8 @@ Adapted from https://github.com/jcrist/msgspec/blob/main/examples/geojson/msgspe
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import msgspec
 
 Position = tuple[float, float]
@@ -78,3 +80,17 @@ _geometry_decoder = msgspec.json.Decoder(Geometry)
 def parse_geometry(geojson_str: str) -> Geometry:
     """Parse a GeoJSON geometry string (from ST_AsGeoJSON) into a Geometry struct."""
     return _geometry_decoder.decode(geojson_str)
+
+
+def stream_feature_collection(features: list[Feature]) -> Iterator[bytes]:
+    """Yield a GeoJSON FeatureCollection incrementally.
+
+    The DB query is complete before this is called — no connection is held
+    during streaming. A client hangup mid-stream has no effect on the pool.
+    """
+    yield b'{"type":"FeatureCollection","features":['
+    for i, feat in enumerate(features):
+        if i > 0:
+            yield b","
+        yield msgspec.json.encode(feat)
+    yield b"]}"

--- a/src/nldi/jsonld.py
+++ b/src/nldi/jsonld.py
@@ -7,6 +7,9 @@ into a JSON-LD graph using schema.org, hydrologic features, and geosparql
 vocabularies.
 """
 
+import json as _json
+from collections.abc import Iterator
+
 JSONLD_CONTEXT = [
     {
         "schema": "https://schema.org/",
@@ -90,3 +93,18 @@ def to_jsonld_single(feature: dict) -> dict:
     """Convert a single feature to a root-level JSON-LD document."""
     entry = feature_to_jsonld(feature.get("properties", {}), feature.get("geometry"))
     return {"@context": JSONLD_CONTEXT, **entry}
+
+
+def stream_jsonld_graph(features: list[dict]) -> Iterator[bytes]:
+    """Yield a JSON-LD @graph incrementally.
+
+    The DB query is complete before this is called — no connection is held
+    during streaming.
+    """
+    header = _json.dumps({"@context": JSONLD_CONTEXT, "@id": "_:graph", "@graph": []})
+    yield header[:-2].encode()  # strip trailing `]}`
+    for i, feat in enumerate(features):
+        if i > 0:
+            yield b","
+        yield _json.dumps(feature_to_jsonld(feat.get("properties", {}), feat.get("geometry"))).encode()
+    yield b"]}"

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -103,6 +103,14 @@ class TestEndpointIntegration:
         body = r.json()
         assert "@context" in body
 
+    def test_nav_jsonld(self, app_client):
+        r = app_client.get("/api/nldi/linked-data/comid/13297166/navigation/UM/wqp?distance=10&f=jsonld")
+        assert r.status_code == 200
+        assert "application/ld+json" in r.headers["content-type"]
+        body = r.json()
+        assert "@context" in body
+        assert "@graph" in body
+
     def test_health_pool_stats(self, app_client):
         r = app_client.get("/api/nldi/about/health")
         assert r.status_code == 200

--- a/tests/unit/test_geojson.py
+++ b/tests/unit/test_geojson.py
@@ -60,3 +60,27 @@ def test_parse_geojson_linestring():
     geom = parse_geometry('{"type": "LineString", "coordinates": [[-89.0, 43.0], [-89.1, 43.1]]}')
     assert isinstance(geom, LineString)
     assert len(geom.coordinates) == 2
+
+
+def test_stream_feature_collection_empty():
+    from nldi.geojson import stream_feature_collection
+
+    result = json.loads(b"".join(stream_feature_collection([])))
+    assert result == {"type": "FeatureCollection", "features": []}
+
+
+def test_stream_feature_collection_single():
+    from nldi.geojson import Feature, Point, stream_feature_collection
+
+    features = [Feature(geometry=Point(coordinates=(-89.0, 43.0)), properties={"id": "1"})]
+    result = json.loads(b"".join(stream_feature_collection(features)))
+    assert result["type"] == "FeatureCollection"
+    assert len(result["features"]) == 1
+
+
+def test_stream_feature_collection_multiple():
+    from nldi.geojson import Feature, Point, stream_feature_collection
+
+    features = [Feature(geometry=Point(coordinates=(-89.0 - i, 43.0)), properties={"id": str(i)}) for i in range(5)]
+    result = json.loads(b"".join(stream_feature_collection(features)))
+    assert len(result["features"]) == 5


### PR DESCRIPTION
See [spec](docs/specs/streaming-nav-responses.md). Improve time-to-first-byte on navigation endpoints by streaming GeoJSON serialization rather than materializing the full response before sending.