### PR TITLE
Fix N+1 queries on navigation endpoints

### DIFF
--- a/src/nldi/db/models.py
+++ b/src/nldi/db/models.py
@@ -145,7 +145,7 @@ class FlowlineModel(NHDBaseModel):
         MainstemLookupModel,
         primaryjoin=lambda: FlowlineModel.nhdplus_comid == MainstemLookupModel.nhdpv2_comid,
         foreign_keys=[nhdplus_comid],
-        lazy="immediate",
+        lazy="noload",
     )
     mainstem: AssociationProxy[str] = association_proxy("mainstem_lookup", "uri")
 

--- a/src/nldi/db/repos.py
+++ b/src/nldi/db/repos.py
@@ -116,7 +116,10 @@ class FeatureRepository(AsyncRepository):
                 .join(CrawlerSourceModel, FeatureSourceModel.crawler_source_id == CrawlerSourceModel.crawler_source_id)
                 .join(subq, FeatureSourceModel.comid == subq.c.comid)
                 .where(sqlalchemy.func.lower(CrawlerSourceModel.source_suffix) == data_source.lower())
-                .options(sqlalchemy.orm.joinedload(FeatureSourceModel.mainstem_lookup))
+                .options(
+                    sqlalchemy.orm.joinedload(FeatureSourceModel.crawler_source),
+                    sqlalchemy.orm.joinedload(FeatureSourceModel.mainstem_lookup),
+                )
             )
             return list(await self.list(statement=stmt))
         finally:

--- a/src/nldi/db/repos.py
+++ b/src/nldi/db/repos.py
@@ -116,6 +116,7 @@ class FeatureRepository(AsyncRepository):
                 .join(CrawlerSourceModel, FeatureSourceModel.crawler_source_id == CrawlerSourceModel.crawler_source_id)
                 .join(subq, FeatureSourceModel.comid == subq.c.comid)
                 .where(sqlalchemy.func.lower(CrawlerSourceModel.source_suffix) == data_source.lower())
+                .options(sqlalchemy.orm.joinedload(FeatureSourceModel.mainstem_lookup))
             )
             return list(await self.list(statement=stmt))
         finally:

--- a/src/nldi/db/repos.py
+++ b/src/nldi/db/repos.py
@@ -117,7 +117,7 @@ class FeatureRepository(AsyncRepository):
                 .join(subq, FeatureSourceModel.comid == subq.c.comid)
                 .where(sqlalchemy.func.lower(CrawlerSourceModel.source_suffix) == data_source.lower())
                 .options(
-                    sqlalchemy.orm.joinedload(FeatureSourceModel.crawler_source),
+                    sqlalchemy.orm.contains_eager(FeatureSourceModel.crawler_source),
                     sqlalchemy.orm.joinedload(FeatureSourceModel.mainstem_lookup),
                 )
             )


### PR DESCRIPTION
Eliminate unnecessary mainstem_lookup eager loads that were causing N+1 query patterns on navigation endpoints, resulting in 60s+ response times against remote RDS.