### PR TITLE
feat: switch basin queries to characteristic_data schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+### Changed
+
+- Basin queries (`/basin` endpoint) now use `characteristic_data` schema tables
+  (`plusflowlinevaa_np21`, `catchmentsp`) instead of `nhdplus` schema, resolving
+  timeout issues on large upstream networks (#202).

--- a/src/nldi/db/models.py
+++ b/src/nldi/db/models.py
@@ -115,6 +115,54 @@ class FeatureSourceModel(NLDIBaseModel):
 
 
 # ---------------------------------------------------------------------------
+# characteristic_data schema
+# ---------------------------------------------------------------------------
+
+
+class CharacteristicDataBaseModel(DeclarativeBase):
+    """Base for tables in the characteristic_data schema."""
+
+    metadata = MetaData(schema="characteristic_data")
+
+
+class CharacteristicCatchmentModel(CharacteristicDataBaseModel):
+    """Catchment polygons — characteristic_data.catchmentsp table.
+
+    Leaner than nhdplus.catchmentsp (3 columns vs 7). Used for basin
+    geometry aggregation where the narrower rows reduce I/O.
+    """
+
+    __tablename__ = "catchmentsp"
+
+    ogc_fid: Mapped[int] = mapped_column(Integer, primary_key=True, nullable=True)
+    the_geom: Mapped[Any] = mapped_column(GeoJSONGeometry, nullable=True)
+    featureid: Mapped[int] = mapped_column(Integer, nullable=True)
+
+
+class CharacteristicFlowlineVAAModel(CharacteristicDataBaseModel):
+    """Flowline VAA — characteristic_data.plusflowlinevaa_np21 table.
+
+    Same columns as :class:`FlowlineVAAModel` but in the characteristic_data
+    schema, which has better indexing for basin traversal queries.
+    """
+
+    __tablename__ = "plusflowlinevaa_np21"
+
+    comid: Mapped[int] = mapped_column(Integer, primary_key=True)
+    hydroseq: Mapped[int] = mapped_column(Integer)
+    levelpathid: Mapped[int] = mapped_column(Integer)
+    pathlength: Mapped[float] = mapped_column(Float)
+    terminalpathid: Mapped[int] = mapped_column(Integer)
+    startflag: Mapped[int] = mapped_column(SmallInteger, nullable=True)
+    terminalflag: Mapped[int] = mapped_column(SmallInteger, nullable=True)
+    uphydroseq: Mapped[int] = mapped_column(Integer)
+    dnminorhyd: Mapped[int] = mapped_column(Integer)
+    dnhydroseq: Mapped[int] = mapped_column(Integer)
+    lengthkm: Mapped[float] = mapped_column(Float)
+    fcode: Mapped[int] = mapped_column(Integer, nullable=True)
+
+
+# ---------------------------------------------------------------------------
 # nhdplus schema
 # ---------------------------------------------------------------------------
 

--- a/src/nldi/db/navigation.py
+++ b/src/nldi/db/navigation.py
@@ -14,7 +14,7 @@ from enum import StrEnum
 from sqlalchemy import Select, and_, bindparam, select
 from sqlalchemy.orm import aliased
 
-from .models import FlowlineVAAModel
+from .models import CharacteristicFlowlineVAAModel, FlowlineVAAModel
 
 COASTAL_FCODE = 56600
 
@@ -315,34 +315,23 @@ def basin_query(comid: int) -> Select:
     Returns comids of all upstream flowlines. Join to catchmentsp and
     ST_Union the geometries to get the drainage basin polygon.
 
-    Matches Java mybatis stream.xml basin query. Should compile to::
-
-        WITH RECURSIVE nav(comid, hydroseq, startflag) AS (
-            SELECT comid, hydroseq, startflag
-            FROM nhdplus.plusflowlinevaa_np21
-            WHERE comid = :comid
-            UNION
-            SELECT vaa.comid, vaa.hydroseq, vaa.startflag
-            FROM nhdplus.plusflowlinevaa_np21 vaa, nav
-            WHERE nav.startflag != 1
-              AND (vaa.dnhydroseq = nav.hydroseq
-                   OR (vaa.dnminorhyd != 0 AND vaa.dnminorhyd = nav.hydroseq))
-        )
-        SELECT nav.comid FROM nav
+    Uses characteristic_data.plusflowlinevaa_np21 for better index
+    performance on large upstream networks, consistent with the Java
+    implementation.
     """
     from sqlalchemy import or_
 
     nav = (
         select(
-            FlowlineVAAModel.comid,
-            FlowlineVAAModel.hydroseq,
-            FlowlineVAAModel.startflag,
+            CharacteristicFlowlineVAAModel.comid,
+            CharacteristicFlowlineVAAModel.hydroseq,
+            CharacteristicFlowlineVAAModel.startflag,
         )
-        .where(FlowlineVAAModel.comid == bindparam("comid"))
+        .where(CharacteristicFlowlineVAAModel.comid == bindparam("comid"))
         .cte("nav", recursive=True)
     )
 
-    vaa = aliased(FlowlineVAAModel, name="vaa")
+    vaa = aliased(CharacteristicFlowlineVAAModel, name="vaa")
     nav_basin = nav.union(
         select(vaa.comid, vaa.hydroseq, vaa.startflag).where(
             and_(

--- a/src/nldi/db/repos.py
+++ b/src/nldi/db/repos.py
@@ -10,7 +10,7 @@ import geoalchemy2
 import sqlalchemy
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .models import CatchmentModel, CrawlerSourceModel, FeatureSourceModel, FlowlineModel
+from .models import CatchmentModel, CharacteristicCatchmentModel, CrawlerSourceModel, FeatureSourceModel, FlowlineModel
 
 
 class AsyncRepository:
@@ -40,6 +40,7 @@ class AsyncRepository:
         if not pid:
             return
         import logging
+
         logging.getLogger(__name__).debug("Cancelling query on backend PID %s", pid)
         from . import get_cancel_engine
 
@@ -346,6 +347,7 @@ class CatchmentRepository(AsyncRepository):
         if not self._cancel_pid:
             return
         import logging
+
         logger = logging.getLogger(__name__)
         logger.debug("Closing connection for basin PID %s", self._cancel_pid)
         try:
@@ -366,21 +368,27 @@ class CatchmentRepository(AsyncRepository):
         """Aggregate upstream catchment polygons into a basin geometry.
 
         Returns GeoJSON string of the unioned polygon, optionally simplified.
+        Uses characteristic_data.catchmentsp for better I/O performance on
+        large upstream networks.
         """
         self._cancel_pid = await self.session.scalar(sqlalchemy.text("SELECT pg_backend_pid()"))
         try:
             subq = basin_nav_query.subquery()
             if simplified:
                 geom = sqlalchemy.func.ST_AsGeoJSON(
-                    sqlalchemy.func.ST_Simplify(sqlalchemy.func.ST_Union(CatchmentModel.the_geom), 0.001), 9, 0
+                    sqlalchemy.func.ST_Simplify(sqlalchemy.func.ST_Union(CharacteristicCatchmentModel.the_geom), 0.001),
+                    9,
+                    0,
                 )
             else:
-                geom = sqlalchemy.func.ST_AsGeoJSON(sqlalchemy.func.ST_Union(CatchmentModel.the_geom), 9, 0)
+                geom = sqlalchemy.func.ST_AsGeoJSON(
+                    sqlalchemy.func.ST_Union(CharacteristicCatchmentModel.the_geom), 9, 0
+                )
 
             stmt = (
                 sqlalchemy.select(geom.label("shape"))
                 .select_from(subq)
-                .join(CatchmentModel, subq.c.comid == CatchmentModel.featureid)
+                .join(CharacteristicCatchmentModel, subq.c.comid == CharacteristicCatchmentModel.featureid)
             )
             result = await self.session.execute(stmt)
             row = result.fetchone()

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -14,3 +14,27 @@ def test_all_models_import():
     assert FlowlineModel.__tablename__ == "nhdflowline_np21"
     assert FlowlineVAAModel.__tablename__ == "plusflowlinevaa_np21"
     assert CatchmentModel.__tablename__ == "catchmentsp"
+
+
+def test_characteristic_data_base_model_schema():
+    from nldi.db.models import CharacteristicDataBaseModel
+
+    assert CharacteristicDataBaseModel.metadata.schema == "characteristic_data"
+
+
+def test_characteristic_catchment_model():
+    from sqlalchemy import inspect
+
+    from nldi.db.models import CharacteristicCatchmentModel
+
+    assert CharacteristicCatchmentModel.__tablename__ == "catchmentsp"
+    assert CharacteristicCatchmentModel.metadata.schema == "characteristic_data"
+    columns = {c.key for c in inspect(CharacteristicCatchmentModel).mapper.column_attrs}
+    assert columns == {"ogc_fid", "featureid", "the_geom"}
+
+
+def test_characteristic_flowline_vaa_model():
+    from nldi.db.models import CharacteristicFlowlineVAAModel
+
+    assert CharacteristicFlowlineVAAModel.__tablename__ == "plusflowlinevaa_np21"
+    assert CharacteristicFlowlineVAAModel.metadata.schema == "characteristic_data"

--- a/tests/unit/test_navigation_query.py
+++ b/tests/unit/test_navigation_query.py
@@ -55,3 +55,23 @@ def test_navigation_query_invalid_mode():
 
     with pytest.raises(ValueError, match="Invalid navigation mode"):
         navigation_query("BOGUS", comid=123, distance=10)
+
+
+def test_basin_query_uses_characteristic_data():
+    from nldi.db.navigation import basin_query
+
+    query = basin_query(13293396)
+    sql = str(query.compile(compile_kwargs={"literal_binds": True}))
+    assert "characteristic_data.plusflowlinevaa_np21" in sql
+    assert "nhdplus.plusflowlinevaa_np21" not in sql
+
+
+def test_navigation_ctes_use_nhdplus():
+    """Characterization: dm, dd, um, ut must use nhdplus, not characteristic_data."""
+    from nldi.db.navigation import dd, dm, um, ut
+
+    for builder in (dm, dd, um, ut):
+        query = builder(comid=13293396, distance=10)
+        sql = str(query.compile(compile_kwargs={"literal_binds": True}))
+        assert "nhdplus.plusflowlinevaa_np21" in sql, f"{builder.__name__} missing nhdplus reference"
+        assert "characteristic_data" not in sql, f"{builder.__name__} should not reference characteristic_data"

--- a/tests/unit/test_repos.py
+++ b/tests/unit/test_repos.py
@@ -9,3 +9,22 @@ def test_repos_instantiate():
     assert FeatureRepository(session=session) is not None
     assert FlowlineRepository(session=session) is not None
     assert CatchmentRepository(session=session) is not None
+
+
+def test_get_drainage_basin_uses_characteristic_data():
+    """get_drainage_basin must join on characteristic_data.catchmentsp, not nhdplus."""
+    import inspect as _inspect
+
+    from nldi.db.repos import CatchmentRepository
+
+    source = _inspect.getsource(CatchmentRepository.get_drainage_basin)
+    assert "CharacteristicCatchmentModel" in source, "get_drainage_basin should use CharacteristicCatchmentModel"
+
+
+def test_catchment_repository_model_type_is_nhdplus():
+    """Characterization: CatchmentRepository.model_type must remain nhdplus.CatchmentModel."""
+    from nldi.db.models import CatchmentModel
+    from nldi.db.repos import CatchmentRepository
+
+    assert CatchmentRepository.model_type is CatchmentModel
+    assert CatchmentModel.metadata.schema == "nhdplus"


### PR DESCRIPTION
Resolves #202

Switch basin_query() and get_drainage_basin() from nhdplus to characteristic_data schema tables, consistent with the Java implementation. Navigation queries and get_by_point remain on nhdplus.

See docs/specs/catchmentsp-schema-switch.md for the full spec.