### PR TITLE
fix: include measure property in feature responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Feature responses now include `measure` property on source feature endpoints
+  (`/linked-data/{source}`, `/linked-data/{source}/{id}`, and feature
+  navigation), restoring parity with the Java NLDI API.
+
 ## 3.0.1
 
 ### Changed

--- a/src/nldi/controllers/linked_data/__init__.py
+++ b/src/nldi/controllers/linked_data/__init__.py
@@ -115,6 +115,7 @@ def _build_source_feature(feat, base_url: str, source_name: str) -> Feature:
             "type": feat.feature_type_proxy,
             "uri": feat.uri,
             "reachcode": feat.reachcode or None,
+            "measure": feat.measure if feat.measure is not None else None,
             "mainstem": feat.mainstem if feat.mainstem and feat.mainstem != "NA" else None,
         },
         id=feat.identifier,

--- a/tests/unit/test_single_feature.py
+++ b/tests/unit/test_single_feature.py
@@ -57,6 +57,42 @@ class TestSingleFeature:
             assert "navigation" in props
             assert props["navigation"].endswith("/linked-data/wqp/USGS-01/navigation")
 
+    def test_feature_includes_measure_property(
+        self, fake_source_repo, make_source, fake_feature_repo, make_feature, fake_flowline_repo
+    ):
+        """Feature properties must include 'measure' (parity with Java NLDI)."""
+        feat = make_feature("USGS-01", "wqp", "Water Quality Portal", "Test Site", "https://example.com/USGS-01")
+        feat.measure = 42.5
+        app = _app_with_fakes(
+            fake_source_repo([make_source("wqp", "Water Quality Portal")]),
+            fake_feature_repo([feat]),
+            fake_flowline_repo([]),
+        )
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/wqp/USGS-01")
+            assert r.status_code == 200
+            props = r.json()["features"][0]["properties"]
+            assert "measure" in props
+            assert props["measure"] == 42.5
+
+    def test_feature_measure_is_null_when_absent(
+        self, fake_source_repo, make_source, fake_feature_repo, make_feature, fake_flowline_repo
+    ):
+        """When the DB measure is NULL, the 'measure' property should be null."""
+        feat = make_feature("USGS-02", "wqp", "Water Quality Portal", "Test Site", "https://example.com/USGS-02")
+        # feat.measure is None by default in the fake
+        app = _app_with_fakes(
+            fake_source_repo([make_source("wqp", "Water Quality Portal")]),
+            fake_feature_repo([feat]),
+            fake_flowline_repo([]),
+        )
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/wqp/USGS-02")
+            assert r.status_code == 200
+            props = r.json()["features"][0]["properties"]
+            assert "measure" in props
+            assert props["measure"] is None
+
     def test_invalid_comid_returns_400(self, fake_source_repo, fake_feature_repo, fake_flowline_repo):
         app = _app_with_fakes(fake_source_repo([]), fake_feature_repo([]), fake_flowline_repo([]))
         with TestClient(app=app) as client:


### PR DESCRIPTION
## Summary

The `measure` property (position along NHD reach, 0-100) was missing from GeoJSON feature responses on source feature endpoints, breaking parity with the Java NLDI API.

Example: `/linked-data/nwissite/USGS-05428500?f=json` was returning properties with `reachcode` but no `measure`. The Java API includes both.

## Scope

Fixes all endpoints that use `_build_source_feature`:
- `GET /linked-data/{source}` (list features by source)
- `GET /linked-data/{source}/{id}` (single feature lookup) ← reported case
- `GET /linked-data/{source}/{id}/navigation/{mode}/{data_source}` (navigation features)

## Implementation plan

TDD cycle:
1. **Red** — added two unit tests in `tests/unit/test_single_feature.py` asserting `measure` appears in properties (populated value + null when DB is NULL). Confirmed failure.
2. **Green** — added one line to `_build_source_feature` in `src/nldi/controllers/linked_data/__init__.py`:
   ```python
   "measure": feat.measure if feat.measure is not None else None,
   ```
   Uses `is not None` (rather than the truthy check used for `comid`) to preserve `0.0` as a valid measure — only NULL in the DB becomes null in the response.
3. **Verify** — all tests green.

## Parity evidence

The Java NLDI parity golden file `tests/parity/fixtures/features_by_source.json` (captured from `/linked-data/nwissite?f=json`) lists `measure` among its `property_keys`, confirming the Java API includes it.

## Quality gate

| Gate | Result |
|---|---|
| Format check (ruff) | pass |
| Lint (ruff) | pass |
| Unit tests | 124/124 pass |
| Integration tests | 38/38 pass |
| Typecheck (ty) | pass |
| Changelog | Unreleased entry added |
