### PR TITLE
fix: use public base URL for browser redirect link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Browser-facing HTML landing page now generates its JSON link using the
+  configured public base URL (``NLDI_URL`` + ``NLDI_PATH``) instead of
+  ``request.url``. Behind a reverse proxy such as CloudFront, the link
+  previously leaked the origin-facing scheme and host (e.g. the CloudFront
+  distribution hostname).
+
 ## 3.0.1
 
 ### Changed

--- a/src/nldi/negotiate.py
+++ b/src/nldi/negotiate.py
@@ -6,6 +6,7 @@ from litestar import Response
 from litestar.connection import Request
 from litestar.exceptions import ClientException
 
+from .config import get_base_url, get_prefix
 from .media import MediaType
 
 VALID_FORMATS = {"json", "jsonld", "html", ""}
@@ -22,6 +23,11 @@ async def check_format(request: Request) -> Response | None:
     If f= is present and invalid, raises 400.
     If f= is absent and the client accepts text/html (browser), returns
     a small HTML page linking to the JSON version.
+
+    The link is built from the configured public base URL (``NLDI_URL`` +
+    ``NLDI_PATH``) rather than ``request.url``, because behind a reverse
+    proxy (e.g. CloudFront) ``request.url`` reflects the origin-facing
+    scheme and host, not the viewer-facing ones.
     """
     f = request.query_params.get("f", "")
 
@@ -30,8 +36,16 @@ async def check_format(request: Request) -> Response | None:
         raise ClientException(detail=f"Invalid format '{f}'. Must be one of: {options}")
 
     if not f and MediaType.HTML in request.headers.get("accept", ""):
-        sep = "&" if "?" in str(request.url) else "?"
-        json_url = f"{request.url}{sep}f=json"
+        # Rebuild the URL using the public base URL, preserving only the
+        # path-after-prefix and the original query string.
+        base_url = get_base_url()
+        prefix = get_prefix()
+        path = request.url.path
+        if prefix and path.startswith(prefix):
+            path = path[len(prefix) :]
+        query = request.url.query
+        sep = "&" if query else "?"
+        json_url = f"{base_url}{path}{'?' + query if query else ''}{sep}f=json"
         return Response(
             content=HTML_REDIRECT_TEMPLATE.format(url=json_url),
             status_code=200,

--- a/tests/unit/test_negotiate.py
+++ b/tests/unit/test_negotiate.py
@@ -66,3 +66,39 @@ def test_explicit_f_overrides_accept_html():
         r = client.get("/test?f=json", headers={"Accept": "text/html"})
         assert r.status_code == 200
         assert r.json()["format"] == "json"
+
+
+def test_browser_redirect_uses_public_base_url(monkeypatch):
+    """The HTML redirect link must use NLDI_URL/NLDI_PATH, not the request host.
+
+    When behind a reverse proxy (CloudFront), ``request.url`` reflects the
+    origin-facing scheme and host, not the viewer-facing ones. The redirect
+    link must use the configured public base URL so viewers get a working
+    link.
+    """
+    monkeypatch.setenv("NLDI_URL", "https://public.example.com")
+    monkeypatch.setenv("NLDI_PATH", "/nldi")
+
+    from litestar import Litestar, get
+    from nldi.negotiate import check_format
+
+    @get("/linked-data/nwissite/{identifier:str}")
+    async def feature(identifier: str, f: str = "") -> dict:
+        return {"format": f, "id": identifier}
+
+    app = Litestar(route_handlers=[feature], path="/nldi", before_request=check_format)
+
+    with TestClient(app=app) as client:
+        # TestClient uses http://testserver as the host (origin-facing, like
+        # the CloudFront distribution hostname in production).
+        r = client.get(
+            "/nldi/linked-data/nwissite/USGS-11120000",
+            headers={"Accept": "text/html"},
+            follow_redirects=False,
+        )
+        assert r.status_code == 200
+        assert "text/html" in r.headers.get("content-type", "")
+        # The link must use the public base URL, not testserver
+        assert "https://public.example.com/nldi/linked-data/nwissite/USGS-11120000" in r.text
+        assert "testserver" not in r.text
+        assert "f=json" in r.text


### PR DESCRIPTION
## Summary

Behind CloudFront, the browser-facing HTML landing page (returned when `Accept: text/html` is sent without an `f=` parameter) was generating its JSON link using the origin-facing request URL. This leaked the internal CloudFront distribution hostname to users.

**Reproduction:**
```
$ curl -s -H 'Accept: text/html' https://api.water.usgs.gov/nldi/linked-data/nwissite/USGS-11120000
<!doctype html>
<html><body>
<p>This is a JSON API. <a href="http://d1olouiv4z7loy.cloudfront.net/nldi/linked-data/nwissite/USGS-11120000?f=json">View as JSON</a>.</p>
</body></html>
```

The `<a>` href should be `https://api.water.usgs.gov/nldi/...`, not `http://d1olouiv4z7loy.cloudfront.net/nldi/...`.

## Root cause

`check_format` built the link from `str(request.url)`. Litestar's `request.url` is reconstructed from the scheme/host of the connection into the ASGI app — which, behind CloudFront, is the origin-facing URL, not the viewer-facing one. CloudFront does not set `X-Forwarded-Host` or preserve the viewer's `Host` header by default.

## Fix

Rebuild the link from the configured public base URL (`NLDI_URL` + `NLDI_PATH`), which is the same pattern the rest of the codebase uses for link generation in GeoJSON responses. The request path (with the app prefix stripped) and query string are preserved from `request.url`.

This sidesteps CloudFront header behavior entirely — no middleware changes needed, no dependency on forwarded headers.

## Implementation plan

TDD cycle:
1. **Red** — added `test_browser_redirect_uses_public_base_url` to `tests/unit/test_negotiate.py` that sets `NLDI_URL=https://public.example.com` + `NLDI_PATH=/nldi`, mounts an app at `/nldi`, and hits it with `Accept: text/html`. Asserts the generated link starts with the public URL and does **not** contain the test server hostname. Confirmed failure.
2. **Green** — in `check_format`, replace `str(request.url)` URL construction with `get_base_url()` + path-after-prefix + query.
3. **Verify** — all 123 unit + 38 integration tests pass.

## Quality gate

| Gate | Result |
|---|---|
| Format check (ruff) | pass |
| Lint (ruff) | pass |
| Unit tests | 123/123 pass (includes new test) |
| Integration tests | 38/38 pass |
| Typecheck (ty) | pass |
| Changelog | Unreleased entry added |
