### PR TITLE
fix: handle pygeoapi errors with 502 and surface upstream detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Fixed
 
+- Errors from the upstream pygeoapi service now return ``502 Bad Gateway``
+  with a problem+json response that surfaces the upstream ``description``
+  (or ``detail``/``message``) in the ``detail`` field, along with an
+  ``upstream_status`` field. Previously any non-timeout pygeoapi error
+  (HTTP 4xx/5xx, invalid JSON, connect failure) fell through to the
+  generic 500 handler and logged a full traceback.
+
 - Browser-facing HTML landing page now generates its JSON link using the
   configured public base URL (``NLDI_URL`` + ``NLDI_PATH``) instead of
   ``request.url``. Behind a reverse proxy such as CloudFront, the link

--- a/src/nldi/asgi.py
+++ b/src/nldi/asgi.py
@@ -32,10 +32,11 @@ from .errors import (
     db_unavailable_handler,
     gateway_timeout_handler,
     problem_details_handler,
+    pygeoapi_error_handler,
     unhandled_exception_handler,
 )
 from .middleware import disconnect_guard_factory, headers_middleware_factory, timing_middleware_factory
-from .pygeoapi import PyGeoAPITimeoutError
+from .pygeoapi import PyGeoAPIError, PyGeoAPITimeoutError
 
 _logger = logging.getLogger(__name__)
 
@@ -79,6 +80,7 @@ def create_app(dependencies: dict | None = None) -> Litestar:
         exception_handlers={  # ty: ignore[invalid-argument-type]
             HTTPException: problem_details_handler,
             PyGeoAPITimeoutError: gateway_timeout_handler,
+            PyGeoAPIError: pygeoapi_error_handler,
             sqlalchemy.exc.SQLAlchemyError: db_unavailable_handler,
             TimeoutError: db_unavailable_handler,
             Exception: unhandled_exception_handler,

--- a/src/nldi/errors.py
+++ b/src/nldi/errors.py
@@ -12,7 +12,7 @@ from litestar import Request, Response
 from litestar.exceptions import HTTPException
 
 from .media import MediaType
-from .pygeoapi import PyGeoAPITimeoutError
+from .pygeoapi import PyGeoAPIError, PyGeoAPITimeoutError
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +60,30 @@ def gateway_timeout_handler(_request: Request[Any, Any, Any], exc: PyGeoAPITimeo
         "instance": f"urn:error:{ref}",
     }
     return Response(content=body, status_code=504, media_type=MediaType.PROBLEM_JSON)
+
+
+def pygeoapi_error_handler(_request: Request[Any, Any, Any], exc: PyGeoAPIError) -> Response[dict[str, Any]]:
+    """Return a 502 Bad Gateway for pygeoapi errors, surfacing upstream detail.
+
+    When the pygeoapi service returns an error response, we pass its
+    description along in the problem+json ``detail`` field so the client
+    sees the underlying reason (e.g. "Error executing process: The NLDI
+    GeoServer failed to return a catchment."). For connect or parse
+    errors without upstream context, a generic detail is used.
+    """
+    ref = uuid.uuid4().hex[:8]
+    logger.warning("pygeoapi error [%s]: %s", ref, exc)
+    detail = exc.upstream_detail or "Upstream service returned an error."
+    body: dict[str, Any] = {
+        "type": "about:blank",
+        "title": "Bad Gateway",
+        "status": 502,
+        "detail": detail,
+        "instance": f"urn:error:{ref}",
+    }
+    if exc.upstream_status is not None:
+        body["upstream_status"] = exc.upstream_status
+    return Response(content=body, status_code=502, media_type=MediaType.PROBLEM_JSON)
 
 
 def _short_tb(exc: Exception, frames: int = 3) -> str:

--- a/src/nldi/pygeoapi.py
+++ b/src/nldi/pygeoapi.py
@@ -16,8 +16,56 @@ logger = logging.getLogger(__name__)
 DEFAULT_TIMEOUT = 20  # seconds
 
 
+def _extract_upstream_detail(response: "httpx.Response") -> str:
+    """Pull a human-readable error detail from a pygeoapi error response.
+
+    pygeoapi typically returns JSON like::
+
+        {"type": "...", "code": "...", "description": "..."}
+
+    Other services may use ``detail`` or ``message``. Falls back to the
+    raw text body (truncated) if nothing structured is found.
+    """
+    try:
+        body = response.json()
+    except (json.JSONDecodeError, ValueError):
+        text = (response.text or "").strip()
+        return text[:500]
+
+    if isinstance(body, dict):
+        for key in ("description", "detail", "message"):
+            value = body.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return str(body)[:500]
+
+
 class PyGeoAPIError(Exception):
-    """Error communicating with pygeoapi service."""
+    """Error communicating with pygeoapi service.
+
+    Carries optional upstream context when the error originated from an
+    HTTP response — ``upstream_status`` is the response code and
+    ``upstream_detail`` is a human-readable description extracted from
+    the response body (pygeoapi returns JSON with ``description``,
+    ``detail``, or ``message`` fields).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        upstream_status: int | None = None,
+        upstream_detail: str = "",
+    ):
+        """Initialize with an error message and optional upstream context.
+
+        :param message: Internal error message (logged, not sent to client).
+        :param upstream_status: HTTP status returned by the upstream service.
+        :param upstream_detail: Human-readable detail from the upstream
+            response body, safe to expose in the API response.
+        """
+        super().__init__(message)
+        self.upstream_status = upstream_status
+        self.upstream_detail = upstream_detail
 
 
 class PyGeoAPITimeoutError(PyGeoAPIError):
@@ -41,14 +89,18 @@ class PyGeoAPIClient:
         try:
             async with httpx.AsyncClient(verify=False) as client:  # noqa: S501
                 r = await client.post(url, content=json.dumps(data), timeout=_timeout)
-                r.raise_for_status()
+                if r.status_code >= 400:
+                    detail = _extract_upstream_detail(r)
+                    raise PyGeoAPIError(
+                        f"HTTP {r.status_code} from {url}: {detail or r.reason_phrase}",
+                        upstream_status=r.status_code,
+                        upstream_detail=detail,
+                    )
                 return r.json()
         except httpx.TimeoutException as e:
             raise PyGeoAPITimeoutError(f"Timeout calling {url}: {e}") from e
         except httpx.ConnectError as e:
             raise PyGeoAPIError(f"Cannot connect to {url}: {e}") from e
-        except httpx.HTTPStatusError as e:
-            raise PyGeoAPIError(f"HTTP error from {url}: {e}") from e
         except json.JSONDecodeError as e:
             raise PyGeoAPIError(f"Invalid JSON from {url}: {e}") from e
 

--- a/tests/unit/test_hydrolocation.py
+++ b/tests/unit/test_hydrolocation.py
@@ -29,6 +29,30 @@ class FakePyGeoAPIClientTimeout:
         raise PyGeoAPITimeoutError("timed out")
 
 
+class FakePyGeoAPIClientUpstream400:
+    """Fake pygeoapi client that raises a PyGeoAPIError with upstream 400 + detail."""
+
+    async def post(self, path, data, timeout=None):
+        from nldi.pygeoapi import PyGeoAPIError
+        raise PyGeoAPIError(
+            "HTTP 400 from upstream",
+            upstream_status=400,
+            upstream_detail="Error executing process: The NLDI GeoServer failed to return a catchment.",
+        )
+
+
+class FakePyGeoAPIClientUpstream429:
+    """Fake pygeoapi client that raises a PyGeoAPIError with upstream 429."""
+
+    async def post(self, path, data, timeout=None):
+        from nldi.pygeoapi import PyGeoAPIError
+        raise PyGeoAPIError(
+            "HTTP 429 from upstream",
+            upstream_status=429,
+            upstream_detail="Too many requests",
+        )
+
+
 def _app_with_fakes(catchment_repo, flowline_repo, pygeoapi_client):
     os.environ.setdefault("NLDI_URL", "https://test.example.com")
     return create_app(dependencies={
@@ -77,3 +101,32 @@ class TestHydrolocation:
         with TestClient(app=app) as client:
             r = client.get("/api/nldi/linked-data/hydrolocation?coords=POINT(-89.509 43.087)")
             assert r.status_code == 504
+
+    def test_pygeoapi_upstream_400_returns_502_with_detail(self, fake_catchment_repo, fake_flowline_repo):
+        """Upstream 4xx from pygeoapi returns 502 problem+json with upstream detail."""
+        app = _app_with_fakes(
+            fake_catchment_repo([]),
+            fake_flowline_repo([]),
+            FakePyGeoAPIClientUpstream400(),
+        )
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/hydrolocation?coords=POINT(-89.509 43.087)")
+            assert r.status_code == 502
+            assert r.headers["content-type"].startswith("application/problem+json")
+            body = r.json()
+            assert body["status"] == 502
+            assert "NLDI GeoServer failed to return a catchment" in body["detail"]
+
+    def test_pygeoapi_upstream_429_returns_502_with_detail(self, fake_catchment_repo, fake_flowline_repo):
+        """Upstream 429 from pygeoapi returns 502 problem+json."""
+        app = _app_with_fakes(
+            fake_catchment_repo([]),
+            fake_flowline_repo([]),
+            FakePyGeoAPIClientUpstream429(),
+        )
+        with TestClient(app=app) as client:
+            r = client.get("/api/nldi/linked-data/hydrolocation?coords=POINT(-89.509 43.087)")
+            assert r.status_code == 502
+            body = r.json()
+            assert body["status"] == 502
+            assert "Too many requests" in body["detail"]

--- a/tests/unit/test_pygeoapi_client.py
+++ b/tests/unit/test_pygeoapi_client.py
@@ -49,3 +49,31 @@ async def test_post_connect_error_raises(monkeypatch):
     client = PyGeoAPIClient("https://fake.example.com/pygeoapi")
     with pytest.raises(PyGeoAPIError, match="connection"):
         await client.post("processes/test/execution", {})
+
+
+async def test_post_http_error_captures_upstream_detail(monkeypatch):
+    """PyGeoAPIError from an HTTP error must carry upstream status and body detail."""
+    import httpx
+    from nldi.pygeoapi import PyGeoAPIClient, PyGeoAPIError
+
+    async def mock_post(self, url, **kwargs):
+        request = httpx.Request("POST", url)
+        response = httpx.Response(
+            status_code=400,
+            request=request,
+            json={
+                "type": "InvalidParameterValue",
+                "code": "InvalidParameterValue",
+                "description": "Error executing process: The NLDI GeoServer failed to return a catchment.",
+            },
+        )
+        return response
+
+    monkeypatch.setattr("httpx.AsyncClient.post", mock_post)
+    client = PyGeoAPIClient("https://fake.example.com/pygeoapi")
+    with pytest.raises(PyGeoAPIError) as exc_info:
+        await client.post("processes/test/execution", {})
+
+    err = exc_info.value
+    assert err.upstream_status == 400
+    assert "NLDI GeoServer failed to return a catchment" in err.upstream_detail


### PR DESCRIPTION
## Summary

Non-timeout errors from the upstream pygeoapi service were falling through to the generic 500 handler and giving clients an opaque `Internal Server Error` with no indication of what went wrong. The production logs showed this happening regularly:

- Client sends `POINT(-80.194 25.314)` (offshore) → pygeoapi returns `400 InvalidParameterValue: The NLDI GeoServer failed to return a catchment` → we returned 500.
- Upstream rate-limits us → 429 Too Many Requests → we returned 500.
- Both logged a full traceback as if they were bugs in our service.

## Fix

1. **Extract upstream detail.** Enhance `PyGeoAPIError` with `upstream_status` and `upstream_detail` attributes. Replace `r.raise_for_status()` with an explicit status check that parses the response body. pygeoapi returns JSON like:
   ```json
   {"type": "InvalidParameterValue", "code": "InvalidParameterValue", "description": "Error executing process: ..."}
   ```
   The helper pulls out `description`, `detail`, or `message` (in that order), falling back to truncated raw text.

2. **Register a handler.** Add `pygeoapi_error_handler` that returns 502 Bad Gateway as problem+json with the upstream detail in `detail` and the upstream status in an `upstream_status` field. Wire it into `exception_handlers` (after `PyGeoAPITimeoutError` so the subclass still gets 504).

3. **Log appropriately.** WARNING with a short message and reference ID, rather than ERROR with full traceback — these are upstream conditions, not bugs.

## Example response

Before (500, opaque):
```json
{"type": "about:blank", "title": "Internal Server Error", "status": 500, "detail": "An unexpected error occurred.", "instance": "urn:error:f452d440"}
```

After (502, actionable):
```json
{"type": "about:blank", "title": "Bad Gateway", "status": 502, "detail": "Error executing process: The NLDI GeoServer failed to return a catchment.", "upstream_status": 400, "instance": "urn:error:abc12345"}
```

## Implementation plan

TDD cycle:
1. **Red (client-level)** — added test asserting `PyGeoAPIError` from an HTTP error carries `upstream_status` and `upstream_detail`. Confirmed failure.
2. **Green (client-level)** — added `_extract_upstream_detail` helper and enhanced `PyGeoAPIError` class.
3. **Red (endpoint-level)** — added hydrolocation tests for upstream 400 and 429 asserting 502 problem+json with detail surfaced. Confirmed failure (showed exact production bug: PyGeoAPIError → unhandled → 500).
4. **Green (endpoint-level)** — added `pygeoapi_error_handler` in `errors.py` and wired it in `asgi.py`.
5. **Verify** — all tests pass, including existing timeout test (confirms 504 still wins for subclass).

## Quality gate

| Gate | Result |
|---|---|
| Format check (ruff) | pass |
| Lint (ruff) | pass |
| Unit tests | 128/128 pass (5 new) |
| Integration tests | 38/38 pass |
| Typecheck (ty) | pass |
| Changelog | Unreleased entry added |
