### PR TITLE
test: characterize OPTIONS verb behavior on assembled app

### DIFF
--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -73,6 +73,38 @@ def test_head_nonexistent_returns_404():
         assert r.status_code == 404
 
 
+def test_options_landing_page():
+    # Characterizes current Litestar behavior: OPTIONS returns 204 with an
+    # Allow header. The exact methods listed are not asserted here because
+    # of an upstream Litestar bug where the Allow header can omit methods
+    # registered via separate decorators on the same path. See
+    # docs/litestar-options-bug-report.md for details.
+    with _client() as client:
+        r = client.options("/api/nldi/")
+        assert r.status_code == 204
+        assert "OPTIONS" in r.headers.get("allow", "")
+        assert r.headers.get("access-control-allow-origin") == "*"
+
+
+def test_options_linked_data_endpoint():
+    # See note on test_options_landing_page above. We assert HEAD and OPTIONS
+    # are present (these survive the bug); GET is intentionally not asserted
+    # because it is currently dropped from the Allow header for paths
+    # covered by both @head and @get.
+    with _client() as client:
+        r = client.options("/api/nldi/linked-data/wqp")
+        assert r.status_code == 204
+        allow = r.headers.get("allow", "")
+        assert "HEAD" in allow
+        assert "OPTIONS" in allow
+
+
+def test_options_nonexistent_returns_404():
+    with _client() as client:
+        r = client.options("/api/nldi/nonexistent")
+        assert r.status_code == 404
+
+
 def test_swagger_ui_redirects_to_docs():
     with _client() as client:
         r = client.get("/api/nldi/swagger-ui/index.html", follow_redirects=False)


### PR DESCRIPTION
## Plan

Add three characterization tests for the `OPTIONS` HTTP verb in `tests/unit/test_routes.py`. They document current Litestar behavior on the assembled NLDI app so a future framework upgrade or local refactor doesn't silently regress it.

### Tests added

1. `test_options_landing_page` — `OPTIONS /api/nldi/` → 204, `Allow` header present, CORS header from middleware present.
2. `test_options_linked_data_endpoint` — `OPTIONS /api/nldi/linked-data/wqp` → 204, `Allow` includes `HEAD` and `OPTIONS`.
3. `test_options_nonexistent_returns_404` — `OPTIONS /api/nldi/nonexistent` → 404 (OPTIONS doesn't paper over routing errors).

### Assertions are intentionally narrow

Assertions characterize **current observed behavior**, not spec-correct behavior. Notably, `GET` is NOT asserted to be in the `Allow` header on paths covered by both an `@head` and a separate `@get` — see the change-of-direction comment below for why.

### TDD note

These are characterization tests (per `.kiro/skills/tdd/SKILL.md`, the explicit exception to red-first). They capture existing behavior rather than driving new behavior.

### Quality gate (run locally)

- `task lint` — passes
- `task format:check` — passes
- `task test:unit` — 128 passed, including the 3 new tests